### PR TITLE
Update testrpc to 4.1.3 and pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.13.1",
-    "ethereumjs-testrpc": "3.0.3",
+    "ethereumjs-testrpc": "4.1.3",
     "solidity-coverage": "^0.2.4",
     "truffle": "3.4.11"
   }


### PR DESCRIPTION
#106 

I think `web3` is exposed globally by truffle and they are on `0.20`. Bringing testrpc up to latest makes us at latest or close for both of the big dev tools. 
