### PR TITLE
Add tests to WTContracts

### DIFF
--- a/contracts/WTContracts.sol
+++ b/contracts/WTContracts.sol
@@ -76,7 +76,7 @@ contract WTContracts is Ownable {
   function getContract(
     uint _pos
   ) constant returns(string, address, string){
-    if (_pos < total)
+    if (_pos <= total)
       return (
         contracts[_pos].name,
         contracts[_pos].addr,

--- a/test/WTContracts.js
+++ b/test/WTContracts.js
@@ -1,44 +1,183 @@
-'use strict';
+const chai = require('chai').assert;
+const help = require('./helpers/index.js');
 
-var chai = require('chai');
-var assert = chai.assert;
-
-var WTContracts = artifacts.require('../contracts/WTContracts.sol');
-
-const DEBUG = true;
+const WTContracts = artifacts.require('./WTContracts.sol');
+const Hotel = artifacts.require('./Hotel.sol');
 
 contract('WTContracts', function(accounts) {
+  const hotelAccount = accounts[2];
+  const nonOwnerAccount = accounts[3];
+  const version = '0.0.1';
+  const nullString = '';
+  const nullAddress = '0x0000000000000000000000000000000000000000';
 
-  it.skip('Should deploy the contractIndex, deploy keysRegistry, register it and edit it', async function() {
+  let contracts;
+  let hotel;
+  let hotelName;
+  let hotelAddress;
+  let owner;
 
-    let contractsIndex = await WTContracts.new();
-    await contractsIndex.register('KeysRegistry', keysRegistry.contract.address, 'http://windingtree.keys.com/', '1.0.0');
-
-    let findByAddr = await contractsIndex.getByAddr(keysRegistry.contract.address);
-    let findByname = await contractsIndex.getByName('KeysRegistry');
-
-    assert.equal(findByAddr[0], findByname[0]);
-    assert.equal(findByAddr[1], findByname[1]);
-    assert.equal(findByAddr[2], findByname[2]);
-    assert.equal(findByAddr[3], findByname[3]);
-    assert.equal('KeysRegistry', findByAddr[0])
-    assert.equal(keysRegistry.contract.address, findByAddr[1])
-    assert.equal('http://windingtree.keys.com/', findByAddr[2]);
-    assert.equal('1.0.0', findByAddr[3]);
-    await  contractsIndex.edit( 'KeysRegistry', keysRegistry.contract.address, 'http://windingtree.keys2.com/', '1.0.1');
-
-    findByAddr = await contractsIndex.getByAddr(keysRegistry.contract.address);
-    findByname = await contractsIndex.getByName('KeysRegistry');
-
-    assert.equal(findByAddr[0], findByname[0]);
-    assert.equal(findByAddr[1], findByname[1]);
-    assert.equal(findByAddr[2], findByname[2]);
-    assert.equal(findByAddr[3], findByname[3]);
-    assert.equal('KeysRegistry', findByAddr[0])
-    assert.equal(keysRegistry.contract.address, findByAddr[1])
-    assert.equal('http://windingtree.keys2.com/', findByAddr[2]);
-    assert.equal('1.0.1', findByAddr[3]);
-
+  beforeEach(async () => {
+    contracts = await WTContracts.new();
+    hotel = await Hotel.new('EuroLux-Zug', 'Valets & Chalets', hotelAccount);
+    hotelName = await hotel.name();
+    hotelAddress = hotel.address;
+    owner = await contracts.owner();
   });
 
+  describe('register', function(){
+
+    it('should register a contract', async () => {
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+      const [ name, addr, version ] = await contracts.getContract(1);
+
+      assert.equal(name, hotelName);
+      assert.equal(addr, hotelAddress);
+      assert.equal(version, version);
+    });
+
+    it('should not register if the contract name exists in the registry', async () => {
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+      const initialTotal = await contracts.total();
+
+      assert.equal(initialTotal.toNumber(), 1);
+
+      await contracts.register(hotelName, contracts.address, hotelAccount);
+      const finalTotal = await contracts.total();
+
+      assert.equal(initialTotal.toNumber(), finalTotal.toNumber());
+    });
+
+    it('should not register if the contract address exists in the registry', async() => {
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+      const initialTotal = await contracts.total();
+
+      assert.equal(initialTotal.toNumber(), 1);
+
+      await contracts.register('Zug-Mountaineer-Hostel', hotelAddress, hotelAccount);
+      const finalTotal = await contracts.total();
+
+      assert.equal(initialTotal.toNumber(), finalTotal.toNumber());
+    });
+
+    it('should throw if a non-owner registers', async () => {
+      try {
+        await contracts.register(hotelName, hotelAddress, hotelAccount, {from: nonOwnerAccount});
+        assert(false);
+      } catch(e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+  });
+
+  describe('edit', function(){
+
+    it('should edit contracts name and address', async() => {
+      const newAddress = accounts[5];
+      const newVersion = '0.0.2';
+
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+      await contracts.edit(hotelName, newAddress, newVersion);
+
+      const [ name, addr, version ] = await contracts.getContract(1);
+
+      assert.equal(name, hotelName);
+      assert.equal(addr, newAddress);
+      assert.equal(version, newVersion);
+    });
+
+    it('should make no changes if contract name not registered', async () => {
+      const newName = 'Zug-Mountaineer-Hostel';
+      const newAddress = accounts[5];
+      const newVersion = '0.0.2';
+
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+      await contracts.edit(newName, newAddress, newVersion);
+
+      const [ name, addr, version ] = await contracts.getContract(1);
+
+      assert.equal(name, hotelName);
+      assert.equal(addr, hotelAddress);
+      assert.equal(version, version);
+    });
+
+    it('should throw if non-owner edits', async () => {
+      const newAddress = accounts[5];
+      const newVersion = '0.0.2';
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+
+      try {
+        await contracts.edit(hotelName, newAddress, newVersion, {from: nonOwnerAccount});
+        assert(false);
+      } catch(e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+  });
+
+  describe('getContract', function(){
+
+    beforeEach( async () => {
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+    })
+
+    it('should return null values if index does not exist', async () => {
+      const total = await contracts.total();
+      const badIndex = total + 1;
+
+      const [ name, addr, version ] = await contracts.getContract(badIndex);
+
+      assert.equal(name, nullString);
+      assert.equal(addr, nullAddress);
+      assert.equal(version, nullString);
+    });
+  });
+
+  describe('getByAddr', function(){
+
+    beforeEach( async () => {
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+    })
+
+    it('should get contract by address', async () => {
+      const [ name, addr, version ] = await contracts.getByAddr(hotelAddress);
+
+      assert.equal(name, hotelName);
+      assert.equal(addr, hotelAddress);
+      assert.equal(version, version);
+    });
+
+    it('should return null values if addr does not exist', async () => {
+      const badAddress = accounts[5];
+      const [ name, addr, version ] = await contracts.getByAddr(badAddress);
+
+      assert.equal(name, nullString);
+      assert.equal(addr, nullAddress);
+      assert.equal(version, nullString);
+    });
+  });
+
+  describe('getByName', function(){
+
+    beforeEach( async () => {
+      await contracts.register(hotelName, hotelAddress, hotelAccount);
+    })
+
+    it('should get contract by name', async () => {
+      const [ name, addr, version ] = await contracts.getByName(hotelName);
+
+      assert.equal(name, hotelName);
+      assert.equal(addr, hotelAddress);
+      assert.equal(version, version);
+    });
+
+    it('should return null values if addr does not exist', async () => {
+      const badName = 'Zug-Mountaineer-Hostel';
+      const [ name, addr, version ] = await contracts.getByName(badName);
+
+      assert.equal(name, nullString);
+      assert.equal(addr, nullAddress);
+      assert.equal(version, nullString);
+    });
+  });
 });


### PR DESCRIPTION
This just covers WTContracts. 

There was one small change to the Solidity. The `total` is incremented before a contract so the indexing starts at one and the most recent record's index is always equal to the total.

Looked at coverage including this and it's now in the low-mid 90's (total).