### PR TITLE
Check for past dates in Unit.book

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -7,6 +7,8 @@ module.exports = {
     'lif/LifToken.sol',
     'lif/Migrations.sol',
     'lif/SmartToken.sol',
-    'lif/VestedPayment.sol'
+    'lif/VestedPayment.sol',
+    'DateTime.sol',
+    'DateTimeAPI.sol'
   ]
 }

--- a/contracts/DateTime.sol
+++ b/contracts/DateTime.sol
@@ -1,0 +1,217 @@
+//From https://github.com/pipermerriam/ethereum-datetime
+pragma solidity ^0.4.16;
+
+contract DateTime {
+        /*
+         *  Date and Time utilities for ethereum contracts
+         *
+         */
+        struct _DateTime {
+                uint16 year;
+                uint8 month;
+                uint8 day;
+                uint8 hour;
+                uint8 minute;
+                uint8 second;
+                uint8 weekday;
+        }
+
+        uint constant DAY_IN_SECONDS = 86400;
+        uint constant YEAR_IN_SECONDS = 31536000;
+        uint constant LEAP_YEAR_IN_SECONDS = 31622400;
+
+        uint constant HOUR_IN_SECONDS = 3600;
+        uint constant MINUTE_IN_SECONDS = 60;
+
+        uint16 constant ORIGIN_YEAR = 1970;
+
+        function isLeapYear(uint16 year) public pure returns (bool) {
+                if (year % 4 != 0) {
+                        return false;
+                }
+                if (year % 100 != 0) {
+                        return true;
+                }
+                if (year % 400 != 0) {
+                        return false;
+                }
+                return true;
+        }
+
+        function leapYearsBefore(uint year) public pure returns (uint) {
+                year -= 1;
+                return year / 4 - year / 100 + year / 400;
+        }
+
+        function getDaysInMonth(uint8 month, uint16 year) public pure returns (uint8) {
+                if (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12) {
+                        return 31;
+                }
+                else if (month == 4 || month == 6 || month == 9 || month == 11) {
+                        return 30;
+                }
+                else if (isLeapYear(year)) {
+                        return 29;
+                }
+                else {
+                        return 28;
+                }
+        }
+
+        function parseTimestamp(uint timestamp) internal pure returns (_DateTime dt) {
+                uint secondsAccountedFor = 0;
+                uint buf;
+                uint8 i;
+
+                // Year
+                dt.year = getYear(timestamp);
+                buf = leapYearsBefore(dt.year) - leapYearsBefore(ORIGIN_YEAR);
+
+                secondsAccountedFor += LEAP_YEAR_IN_SECONDS * buf;
+                secondsAccountedFor += YEAR_IN_SECONDS * (dt.year - ORIGIN_YEAR - buf);
+
+                // Month
+                uint secondsInMonth;
+                for (i = 1; i <= 12; i++) {
+                        secondsInMonth = DAY_IN_SECONDS * getDaysInMonth(i, dt.year);
+                        if (secondsInMonth + secondsAccountedFor > timestamp) {
+                                dt.month = i;
+                                break;
+                        }
+                        secondsAccountedFor += secondsInMonth;
+                }
+
+                // Day
+                for (i = 1; i <= getDaysInMonth(dt.month, dt.year); i++) {
+                        if (DAY_IN_SECONDS + secondsAccountedFor > timestamp) {
+                                dt.day = i;
+                                break;
+                        }
+                        secondsAccountedFor += DAY_IN_SECONDS;
+                }
+
+                // Hour
+                dt.hour = getHour(timestamp);
+
+                // Minute
+                dt.minute = getMinute(timestamp);
+
+                // Second
+                dt.second = getSecond(timestamp);
+
+                // Day of week.
+                dt.weekday = getWeekday(timestamp);
+        }
+
+        function getYear(uint timestamp) public pure returns (uint16) {
+                uint secondsAccountedFor = 0;
+                uint16 year;
+                uint numLeapYears;
+
+                // Year
+                year = uint16(ORIGIN_YEAR + timestamp / YEAR_IN_SECONDS);
+                numLeapYears = leapYearsBefore(year) - leapYearsBefore(ORIGIN_YEAR);
+
+                secondsAccountedFor += LEAP_YEAR_IN_SECONDS * numLeapYears;
+                secondsAccountedFor += YEAR_IN_SECONDS * (year - ORIGIN_YEAR - numLeapYears);
+
+                while (secondsAccountedFor > timestamp) {
+                        if (isLeapYear(uint16(year - 1))) {
+                                secondsAccountedFor -= LEAP_YEAR_IN_SECONDS;
+                        }
+                        else {
+                                secondsAccountedFor -= YEAR_IN_SECONDS;
+                        }
+                        year -= 1;
+                }
+                return year;
+        }
+
+        function getMonth(uint timestamp) public pure returns (uint8) {
+                return parseTimestamp(timestamp).month;
+        }
+
+        function getDay(uint timestamp) public pure returns (uint8) {
+                return parseTimestamp(timestamp).day;
+        }
+
+        function getHour(uint timestamp) public pure returns (uint8) {
+                return uint8((timestamp / 60 / 60) % 24);
+        }
+
+        function getMinute(uint timestamp) public pure returns (uint8) {
+                return uint8((timestamp / 60) % 60);
+        }
+
+        function getSecond(uint timestamp) public pure returns (uint8) {
+                return uint8(timestamp % 60);
+        }
+
+        function getWeekday(uint timestamp) public pure returns (uint8) {
+                return uint8((timestamp / DAY_IN_SECONDS + 4) % 7);
+        }
+
+        function toTimestamp(uint16 year, uint8 month, uint8 day) public pure returns (uint timestamp) {
+                return toTimestamp(year, month, day, 0, 0, 0);
+        }
+
+        function toTimestamp(uint16 year, uint8 month, uint8 day, uint8 hour) public pure returns (uint timestamp) {
+                return toTimestamp(year, month, day, hour, 0, 0);
+        }
+
+        function toTimestamp(uint16 year, uint8 month, uint8 day, uint8 hour, uint8 minute) public pure returns (uint timestamp) {
+                return toTimestamp(year, month, day, hour, minute, 0);
+        }
+
+        function toTimestamp(uint16 year, uint8 month, uint8 day, uint8 hour, uint8 minute, uint8 second) public pure returns (uint timestamp) {
+                uint16 i;
+
+                // Year
+                for (i = ORIGIN_YEAR; i < year; i++) {
+                        if (isLeapYear(i)) {
+                                timestamp += LEAP_YEAR_IN_SECONDS;
+                        }
+                        else {
+                                timestamp += YEAR_IN_SECONDS;
+                        }
+                }
+
+                // Month
+                uint8[12] memory monthDayCounts;
+                monthDayCounts[0] = 31;
+                if (isLeapYear(year)) {
+                        monthDayCounts[1] = 29;
+                }
+                else {
+                        monthDayCounts[1] = 28;
+                }
+                monthDayCounts[2] = 31;
+                monthDayCounts[3] = 30;
+                monthDayCounts[4] = 31;
+                monthDayCounts[5] = 30;
+                monthDayCounts[6] = 31;
+                monthDayCounts[7] = 31;
+                monthDayCounts[8] = 30;
+                monthDayCounts[9] = 31;
+                monthDayCounts[10] = 30;
+                monthDayCounts[11] = 31;
+
+                for (i = 1; i < month; i++) {
+                        timestamp += DAY_IN_SECONDS * monthDayCounts[i - 1];
+                }
+
+                // Day
+                timestamp += DAY_IN_SECONDS * (day - 1);
+
+                // Hour
+                timestamp += HOUR_IN_SECONDS * (hour);
+
+                // Minute
+                timestamp += MINUTE_IN_SECONDS * (minute);
+
+                // Second
+                timestamp += second;
+
+                return timestamp;
+        }
+}

--- a/contracts/DateTimeAPI.sol
+++ b/contracts/DateTimeAPI.sol
@@ -1,0 +1,19 @@
+//From https://github.com/pipermerriam/ethereum-datetime
+contract DateTimeAPI {
+        /*
+         *  Abstract contract for interfacing with the DateTime contract.
+         *
+         */
+        function isLeapYear(uint16 year) constant returns (bool);
+        function getYear(uint timestamp) constant returns (uint16);
+        function getMonth(uint timestamp) constant returns (uint8);
+        function getDay(uint timestamp) constant returns (uint8);
+        function getHour(uint timestamp) constant returns (uint8);
+        function getMinute(uint timestamp) constant returns (uint8);
+        function getSecond(uint timestamp) constant returns (uint8);
+        function getWeekday(uint timestamp) constant returns (uint8);
+        function toTimestamp(uint16 year, uint8 month, uint8 day) constant returns (uint timestamp);
+        function toTimestamp(uint16 year, uint8 month, uint8 day, uint8 hour) constant returns (uint timestamp);
+        function toTimestamp(uint16 year, uint8 month, uint8 day, uint8 hour, uint8 minute) constant returns (uint timestamp);
+        function toTimestamp(uint16 year, uint8 month, uint8 day, uint8 hour, uint8 minute, uint8 second) constant returns (uint timestamp);
+}

--- a/contracts/Index_Interface.sol
+++ b/contracts/Index_Interface.sol
@@ -7,5 +7,6 @@ pragma solidity ^0.4.15;
 contract Index_Interface {
 
   address public LifToken;
+  address public DateTime;
 
 }

--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -46,8 +46,11 @@ contract WTIndex is Ownable {
 
   /**
      @dev Constructor. Creates the `WTIndex` contract
+
+     @param _DateTime Address of the DateTime utility contract
    */
-	function WTIndex() {
+	function WTIndex(address _DateTime) {
+    DateTime = _DateTime;
 		hotels.length ++;
 	}
 

--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -26,6 +26,9 @@ contract WTIndex is Ownable {
   // Address of the LifToken contract
   address public LifToken;
 
+  // Address of the DateTime contract
+  address public DateTime;
+
   /**
      @dev Event triggered every time hotel is registered or called
   **/
@@ -66,6 +69,16 @@ contract WTIndex is Ownable {
    */
   function setLifToken(address _LifToken) onlyOwner() {
     LifToken = _LifToken;
+  }
+
+  /**
+     @dev `setDateTime` allows the owner of the contract to change the
+     address of the DateTime contract
+
+     @param _DateTime The new contract address
+   */
+  function setDateTime(address _DateTime) onlyOwner() {
+    DateTime = _DateTime;
   }
 
   /**

--- a/contracts/hotel/Hotel.sol
+++ b/contracts/hotel/Hotel.sol
@@ -145,6 +145,7 @@ contract Hotel is PrivateCall, Images {
     address unit
   ) onlyOwner() {
 		require(unitTypes[Unit_Interface(unit).unitType()] != address(0));
+    Unit_Interface(unit).setDateTime(Index_Interface(owner).DateTime());
     unitsIndex[unit] = units.length;
     units.push(unit);
     UnitType_Interface(unitTypes[Unit_Interface(unit).unitType()]).increaseUnits();
@@ -235,6 +236,7 @@ contract Hotel is PrivateCall, Images {
      @param unitAddress The address of the `Unit` contract
      @param from The address of the opener of the reservation
      @param fromDay The starting day of the period of days to book
+     @param fromDayTimestamp The starting day in seconds since epoch
      @param daysAmount The amount of days in the booking period
      @param finalDataCall The data to execute a call on the `WTIndex` contract
    */
@@ -242,13 +244,14 @@ contract Hotel is PrivateCall, Images {
     address unitAddress,
     address from,
     uint fromDay,
+    uint fromDayTimestamp,
     uint daysAmount,
     bytes finalDataCall
   ) fromSelf() {
     require(unitsIndex[unitAddress] > 0);
     require(daysAmount > 0);
     uint256 price = Unit_Interface(unitAddress).getPrice(fromDay, daysAmount);
-    require(Unit_Interface(unitAddress).book(from, fromDay, daysAmount));
+    require(Unit_Interface(unitAddress).book(from, fromDay, fromDayTimestamp, daysAmount));
     require(ERC20(Index_Interface(owner).LifToken()).transferFrom(from, this, price));
 
     if (finalDataCall.length != 0)

--- a/contracts/hotel/Unit.sol
+++ b/contracts/hotel/Unit.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.15;
 
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../DateTimeAPI.sol";
 
  /**
    @title Unit, contract for an individual unit in a Hotel
@@ -8,9 +9,12 @@ import "zeppelin-solidity/contracts/ownership/Ownable.sol";
    A contract that represents an individual unit of a hotel registered in the
    WT network. Tracks the price and availability of this unit.
 
-   Inherits from WT's `PrivateCall`
+   Inherits from WT's `PrivateCall` and Piper Merriam's `DateTimeAPI`
  */
 contract Unit is Ownable {
+
+  // API for using date and time utilities
+  DateTimeAPI date;
 
   // The type of the unit
   bytes32 public unitType;
@@ -58,6 +62,16 @@ contract Unit is Ownable {
   }
 
   /**
+     @dev `setDateTime` allows the owner of the contract to change the
+     address of the DateTime contract
+
+     @param _date The new contract address
+   */
+  function setDateTime(address _date) onlyOwner() {
+    date = DateTimeAPI(_date);
+  }
+
+  /**
      @dev `setPrice` allows the owner of the contract to set a price for
      a range of dates
 
@@ -84,6 +98,7 @@ contract Unit is Ownable {
 
      @param from The address of the opener of the reservation
      @param fromDay The starting day of the period of days to book
+     @param fromDayTimestamp The starting day in seconds since epoch
      @param daysAmount The amount of days in the booking period
 
      @return bool Whether the booking was successful or not
@@ -91,8 +106,10 @@ contract Unit is Ownable {
   function book(
     address from,
     uint fromDay,
+    uint fromDayTimestamp,
     uint daysAmount
   ) onlyOwner() returns(bool) {
+    require(isFutureDay(fromDayTimestamp));
     require(active);
     uint toDay = fromDay+daysAmount;
 
@@ -142,6 +159,24 @@ contract Unit is Ownable {
     }
 
     return totalPrice;
+  }
+
+  /**
+     @dev `isFutureDay` checks that a timestamp is not a past date
+
+     @param time The number of seconds after 01-01-1970
+
+     @return bool If the timestamp is today or in the future
+   */
+  function isFutureDay(uint time) internal returns (bool) {
+    if (date.getYear(time) < date.getYear(now))
+      return false;
+    if(date.getMonth(time) < date.getMonth(now))
+      return false;
+    if(date.getMonth(time) == date.getMonth(now)
+    && date.getDay(time) <= date.getDay(now))
+      return false;
+    return true;
   }
 
 }

--- a/contracts/hotel/Unit_Interface.sol
+++ b/contracts/hotel/Unit_Interface.sol
@@ -19,8 +19,9 @@ contract Unit_Interface is Ownable {
 
   // Owner methods
   function setActive(bool _active) onlyOwner();
+  function setDateTime(address _date) onlyOwner();
   function setSpecialPrice(string price, uint fromDay, uint daysAmount) onlyOwner();
   function setDefaultLifTokenPrice(uint256 price) onlyOwner();
-  function book(address from, uint fromDay, uint daysAmount) onlyOwner() returns(bool);
+  function book(address from, uint fromDay, uint fromDayTimestamp, uint daysAmount) onlyOwner() returns(bool);
 
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "abi-decoder": "^1.0.8",
     "babel-polyfill": "^6.23.0",
     "chai": "^3.5.0",
-    "moment": "^2.18.1",
+    "moment": "^2.19.1",
     "truffle-hdwallet-provider": "0.0.3",
     "zeppelin-solidity": "1.2.0"
   },
@@ -33,6 +33,6 @@
     "coveralls": "^2.13.1",
     "ethereumjs-testrpc": "4.1.3",
     "solidity-coverage": "^0.2.4",
-    "truffle": "3.4.11"
+    "truffle": "4.0.0-beta.2"
   }
 }

--- a/test/book.js
+++ b/test/book.js
@@ -1,27 +1,42 @@
 const assert = require('chai').assert;
 const help = require('./helpers/index.js');
+const moment = require('moment');
 
 contract('Hotel / PrivateCall: bookings', function(accounts) {
   const augusto = accounts[1];
   const hotelAccount = accounts[2];
   const jakub = accounts[3];
   const typeName = 'BASIC_ROOM';
+  let fromDate;
+  let fromDayTimestamp;
+  let fromDay;
+  let block;
 
-  describe('reservations', function(){
+  describe('reservations', async function(){
     let events;
     let hash;
     let args;
-    const fromDay = 60;
     const daysAmount = 5;
+    const daysFromNow = 1;
     const unitPrice = 1;
+
+    before(async function() {
+      block = await web3.eth.getBlock("latest");
+      fromDate = moment.unix(block.timestamp);
+      fromDate.add(daysFromNow, 'days');
+      fromDay = fromDate.diff(moment(), 'days');
+      fromDayTimestamp = fromDate.unix();
+    })
 
     // Add a unit that accepts instant booking, execute a token.transferData booking
     beforeEach(async function() {
+
       args = [
         augusto,
         hotelAccount,
         accounts,
         fromDay,
+        fromDayTimestamp,
         daysAmount,
         unitPrice
       ];
@@ -50,7 +65,9 @@ contract('Hotel / PrivateCall: bookings', function(accounts) {
     });
 
     it('should make a res that starts on the day a previous res ends', async () => {
-      let nextFrom = fromDay + daysAmount;
+      let nextDate = moment(fromDate).add(daysAmount, 'days');
+      let nextFrom = nextDate.diff(moment(), 'days');
+      let nextTimeStamp = nextDate.unix();
       let nextAmount = 2;
       let options = {keepPreviousHotel: true};
       let newArgs = [
@@ -58,6 +75,7 @@ contract('Hotel / PrivateCall: bookings', function(accounts) {
         hotelAccount,
         accounts,
         nextFrom,
+        nextTimeStamp,
         nextAmount,
         unitPrice,
         options
@@ -72,13 +90,16 @@ contract('Hotel / PrivateCall: bookings', function(accounts) {
     })
 
     it('should throw if zero days are reserved', async () => {
-      let nextFrom = fromDay + daysAmount;
+      let nextDate = moment(fromDate).add(daysAmount, 'months');
+      let nextFrom = nextDate.diff(moment(), 'days');
+      let nextTimeStamp = nextDate.unix();
       let nextAmount = 0;
       let newArgs = [
         jakub,
         hotelAccount,
         accounts,
         nextFrom,
+        nextTimeStamp,
         nextAmount,
         unitPrice
       ];
@@ -88,13 +109,16 @@ contract('Hotel / PrivateCall: bookings', function(accounts) {
     });
 
     it('should should throw if any of the days requested are already reserved', async () => {
-      let takenDay = fromDay + 1;
+      let nextDate = moment(fromDate).add(1, 'days');
+      let nextFrom = nextDate.diff(moment(), 'days');
+      let nextTimeStamp = nextDate.unix();
       let options = {keepPreviousHotel: true};
       let newArgs = [
         jakub,
         hotelAccount,
         accounts,
-        takenDay,
+        nextFrom,
+        nextTimeStamp,
         daysAmount,
         unitPrice,
         options
@@ -112,6 +136,7 @@ contract('Hotel / PrivateCall: bookings', function(accounts) {
         hotelAccount,
         accounts,
         fromDay,
+        fromDayTimestamp,
         daysAmount,
         unitPrice,
         options
@@ -124,14 +149,39 @@ contract('Hotel / PrivateCall: bookings', function(accounts) {
     // This needs:
     // Contract logic about the current date.
     // Combing through the helpers and tests to remove '60' and provide an accurate date.
-    it.skip('should throw when reserving dates in the past');
+    it('should throw when reserving dates in the past', async() => {
+      let pastDate = moment(fromDate).subtract(1, 'months');
+      let nextFrom = pastDate.diff(moment(), 'days');
+      let nextTimeStamp = pastDate.unix();
+      let nextAmount = 2;
+      let newArgs = [
+        augusto,
+        hotelAccount,
+        accounts,
+        nextFrom,
+        nextTimeStamp,
+        daysAmount,
+        unitPrice
+      ];
+
+      const { success } = await help.bookInstantly(...newArgs);
+      assert.equal(success, false);
+    });
   });
 
   describe('instant payment with token', function () {
-    const fromDay = 60;
+    const daysFromNow = 7;
     const daysAmount = 5;
     const unitPrice = 1;
     let args;
+
+    before(async function() {
+      block = await web3.eth.getBlock("latest");
+      fromDate = moment.unix(block.timestamp);
+      fromDate.add(daysFromNow, 'days');
+      fromDay = fromDate.diff(moment(), 'days');
+      fromDayTimestamp = fromDate.unix();
+    })
 
     beforeEach(function() {
       args = [
@@ -139,6 +189,7 @@ contract('Hotel / PrivateCall: bookings', function(accounts) {
         hotelAccount,
         accounts,
         fromDay,
+        fromDayTimestamp,
         daysAmount,
         unitPrice,
       ];
@@ -168,13 +219,16 @@ contract('Hotel / PrivateCall: bookings', function(accounts) {
       await help.bookInstantly(...args);
 
       // Make another booking that overlaps
-      let takenDay = fromDay + 1;
+      let takenDate = moment(fromDate).add(1, 'days');
+      let nextFrom = takenDate.diff(moment(), 'days');
+      let nextTimeStamp = takenDate.unix();
       let options = {keepPreviousHotel: true};
       let newArgs = [
         jakub,
         hotelAccount,
         accounts,
-        takenDay,
+        nextFrom,
+        nextTimeStamp,
         daysAmount,
         unitPrice,
         options

--- a/test/helpers/book.js
+++ b/test/helpers/book.js
@@ -17,9 +17,8 @@ let stubData;
 let accounts;
 
 async function initializeHotel(hotelAccount){
-  index = await WTIndex.new();
   dateTime = await DateTime.new();
-  await index.setDateTime(dateTime.address);
+  index = await WTIndex.new(dateTime.address);
   hotel = await hotelLib.createHotel(index, hotelAccount);
   unitType = await hotelLib.addUnitTypeToHotel(index, hotel, typeName, hotelAccount);
   stubData = index.contract.getHotels.getData();

--- a/test/helpers/book.js
+++ b/test/helpers/book.js
@@ -3,12 +3,14 @@ const hotelLib = require('./hotel');
 
 const WTHotel = artifacts.require('Hotel.sol')
 const WTIndex = artifacts.require('WTIndex.sol');
+const DateTime = artifacts.require('DateTime.sol');
 const LifToken = artifacts.require('LifToken.sol');
 const Unit = artifacts.require('Unit.sol')
 
 const typeName = 'BASIC_ROOM';
 
 let index;
+let dateTime;
 let hotel;
 let unitType;
 let stubData;
@@ -16,6 +18,8 @@ let accounts;
 
 async function initializeHotel(hotelAccount){
   index = await WTIndex.new();
+  dateTime = await DateTime.new();
+  await index.setDateTime(dateTime.address);
   hotel = await hotelLib.createHotel(index, hotelAccount);
   unitType = await hotelLib.addUnitTypeToHotel(index, hotel, typeName, hotelAccount);
   stubData = index.contract.getHotels.getData();
@@ -26,6 +30,7 @@ async function bookInstantly(
   hotelAccount,
   accounts,
   fromDay,
+  fromDayTimestamp,
   daysAmount,
   unitPrice,
   options
@@ -52,6 +57,7 @@ async function bookInstantly(
     unit,
     client,
     fromDay,
+    fromDayTimestamp,
     daysAmount,
     unitPrice,
     tokenMethod,

--- a/test/helpers/privateCall.js
+++ b/test/helpers/privateCall.js
@@ -6,6 +6,7 @@ const LifToken = artifacts.require('LifToken.sol');
 const Unit = artifacts.require('Unit.sol');
 const Hotel = artifacts.require('Hotel.sol');
 const WTIndex = artifacts.require('WTIndex.sol');
+const DateTime = artifacts.require('DateTime.sol');
 
 abiDecoder.addABI(Unit._json.abi);
 abiDecoder.addABI(LifToken._json.abi);
@@ -21,6 +22,7 @@ abiDecoder.addABI(WTIndex._json.abi);
  * @param  {Instance} unit             Unit instance being booked
  * @param  {Address}  client           Address of the person making a booking
  * @param  {Number}   fromDay          Day after 01-01-1970 booking starts
+ * @param  {Number}   fromDayTimestamp Seconds after 01-01-1970 booking starts
  * @param  {Number}   daysAmount       Number of days to book for
  * @param  {Number}   price            Default LifToken price ?
  * @param  {String}   tokenOp          'approveData' || 'transferData' || 'transferDataFrom'
@@ -49,6 +51,7 @@ async function runBeginCall(
   unit,
   client,
   fromDay,
+  fromDayTimestamp,
   daysAmount,
   price,
   tokenOp,
@@ -58,6 +61,8 @@ async function runBeginCall(
 ){
 
   const wtIndex = await WTIndex.at(await hotel.owner());
+  // const dateTime = await DateTime.new();
+  // await wtIndex.setDateTime(dateTime.address);
 
   // Options: userInfo?
   let userInfo;
@@ -92,7 +97,7 @@ async function runBeginCall(
   const clientInitialBalance = await token.balanceOf(client);
 
   // Compose token call
-  const bookData = hotel.contract.book.getData(unit.address, client, fromDay, daysAmount, passThroughData);
+  const bookData = hotel.contract.book.getData(unit.address, client, fromDay, fromDayTimestamp, daysAmount, passThroughData);
   const beginCallData = hotel.contract.beginCall.getData(bookData, userInfo);
 
   const tokenOpCalls = {

--- a/test/hotel.js
+++ b/test/hotel.js
@@ -3,6 +3,7 @@ const help = require('./helpers/index.js');
 const abiDecoder = require('abi-decoder');
 
 const WTIndex = artifacts.require('WTIndex.sol');
+const DateTime = artifacts.require('DateTime.sol');
 const WTHotel = artifacts.require('Hotel.sol');
 const UnitType = artifacts.require('UnitType.sol');
 const UnitTypeInterface = artifacts.require('UnitType_Interface.sol');
@@ -20,11 +21,16 @@ contract('Hotel', function(accounts) {
   const hotelAccount = accounts[2];
   const nonOwnerAccount = accounts[3];
   let wtIndex;
+  let dateTime;
   let wtHotel;
+
+  before(async function() {
+    dateTime = await DateTime.new();
+  })
 
   // Create and register a hotel
   beforeEach( async function(){
-    wtIndex = await WTIndex.new();
+    wtIndex = await WTIndex.new(dateTime.address);
     await wtIndex.registerHotel(hotelName, hotelDescription, {from: hotelAccount});
     let address = await wtIndex.getHotelsByManager(hotelAccount);
     wtHotel = WTHotel.at(address[0]);

--- a/test/privateCall.js
+++ b/test/privateCall.js
@@ -1,9 +1,11 @@
 const assert = require('chai').assert;
 const help = require('./helpers/index.js');
 const abiDecoder = require('abi-decoder');
+const moment = require('moment');
 
 const WTHotel = artifacts.require('Hotel.sol')
 const WTIndex = artifacts.require('WTIndex.sol');
+const DateTime = artifacts.require('DateTime.sol');
 const LifToken = artifacts.require('LifToken.sol');
 const Unit = artifacts.require('Unit.sol')
 
@@ -14,22 +16,34 @@ contract('PrivateCall', function(accounts) {
   const augusto = accounts[1];
   const hotelAccount = accounts[2];
   const typeName = 'BASIC_ROOM';
-  const fromDay = 60;
   const daysAmount = 5;
   const price = 1;
   const unitArgPos = 1;
-  const dataArgPos = 8;
+  const dataArgPos = 9;
 
   let defaultCallArgs;
   let index;
+  let dateTime;
   let hotel;
   let unitType;
   let unit;
   let stubData;
+  let fromDay;
+  let fromDate;
+  let fromDayTimestamp;
 
   // Create and register a hotel
   beforeEach( async function(){
+    block = await web3.eth.getBlock("latest");
+    fromDate = moment.unix(block.timestamp);
+    fromDate.add(1, 'days');
+    fromDay = fromDate.diff(moment(), 'days');
+    fromDayTimestamp = fromDate.unix();
+
     index = await WTIndex.new();
+    dateTime = await DateTime.new();
+    await index.setDateTime(dateTime.address);
+
     hotel = await help.createHotel(index, hotelAccount);
     unitType = await help.addUnitTypeToHotel(index, hotel, typeName, hotelAccount);
     stubData = index.contract.getHotels.getData();
@@ -38,6 +52,7 @@ contract('PrivateCall', function(accounts) {
       null,
       augusto,
       fromDay,
+      fromDayTimestamp,
       daysAmount,
       price,
       'approveData',
@@ -130,7 +145,7 @@ contract('PrivateCall', function(accounts) {
     // We've already begun and indentical call in the beforeEach block. Smart token requires
     // that the call succeeds, so approveData will also throw.
     it('should throw if call is duplicate', async function() {
-      const bookData = hotel.contract.book.getData(unit.address, augusto, 60, 5, stubData);
+      const bookData = hotel.contract.book.getData(unit.address, augusto, fromDay, fromDayTimestamp, 5, stubData);
       const beginCall = hotel.contract.beginCall.getData(bookData, userInfo);
 
       try {
@@ -233,7 +248,7 @@ contract('PrivateCall', function(accounts) {
 
     // This test makes this verifiable by coverage.
     it('fromSelf modifier throws on indirect calls', async function(){
-      const bookData = hotel.contract.book.getData(unit.address, augusto, 60, 5, stubData);
+      const bookData = hotel.contract.book.getData(unit.address, augusto, fromDay, fromDayTimestamp, 5, stubData);
       try {
         await index.callHotel(0, bookData, {from: hotelAccount});
         assert(false);

--- a/test/privateCall.js
+++ b/test/privateCall.js
@@ -32,6 +32,10 @@ contract('PrivateCall', function(accounts) {
   let fromDate;
   let fromDayTimestamp;
 
+  before(async function() {
+    dateTime = await DateTime.new();
+  });
+
   // Create and register a hotel
   beforeEach( async function(){
     block = await web3.eth.getBlock("latest");
@@ -40,10 +44,7 @@ contract('PrivateCall', function(accounts) {
     fromDay = fromDate.diff(moment(), 'days');
     fromDayTimestamp = fromDate.unix();
 
-    index = await WTIndex.new();
-    dateTime = await DateTime.new();
-    await index.setDateTime(dateTime.address);
-
+    index = await WTIndex.new(dateTime.address);
     hotel = await help.createHotel(index, hotelAccount);
     unitType = await help.addUnitTypeToHotel(index, hotel, typeName, hotelAccount);
     stubData = index.contract.getHotels.getData();


### PR DESCRIPTION
Resolves #100 

- Adds DateTime and DateTimeAPI utility contracts from [https://github.com/pipermerriam/ethereum-datetime](https://github.com/pipermerriam/ethereum-datetime)
- Added an address for DateTime to `WTIndex`.  `Hotels` pass it when adding `Units` so the `Unit` can use `DateTime` 
- `DateTime` uses solidity 4.16, so I upgraded truffle to the current beta (the current stable uses solidity 4.13)
- Unit.book now takes another parameter, `fromDayTimestamp` which represents the day of the booking in number of seconds since epoch. This is necessary because the only on-chain time source `block.timestamp` is in seconds
- Adds tests