### PR TITLE
Add tests for WTIndex

### DIFF
--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -21,7 +21,7 @@ contract WTIndex is Ownable {
   mapping(address => address[]) public hotelsByManager;
 
   // The address of the DAO contract
-  address DAO;
+  address public DAO;
 
   // Address of the LifToken contract
   address public LifToken;
@@ -97,12 +97,12 @@ contract WTIndex is Ownable {
 	}
 
   /**
-     @dev `getHotels` Get the addresses of all registered `Hotel` contracts
+     @dev `getHotelsLength` get the length of the `hotels` array
 
-     returns The `Hotel` contract addresses
+     @return uint Length of the `hotels` array
    */
-  function getHotels() constant returns(address[]){
-    return hotels;
+  function getHotelsLength() constant returns (uint) {
+    return hotels.length;
   }
 
   /**

--- a/test/WTIndex.js
+++ b/test/WTIndex.js
@@ -1,0 +1,144 @@
+const chai = require('chai').assert;
+const help = require('./helpers/index.js');
+
+const WTIndex = artifacts.require('./WTIndex.sol');
+
+contract('WTIndex', function(accounts) {
+  const indexOwner = accounts[1];
+  const hotelAccount = accounts[2];
+  const nonOwnerAccount = accounts[3];
+
+  let index;
+
+  beforeEach(async () => {
+    index = await WTIndex.new({from: indexOwner});
+  });
+
+  describe('setDAO', () => {
+    const daoAddress = accounts[4];
+
+    it('should set the DAOs address', async() => {
+      await index.setDAO(daoAddress, {from: indexOwner});
+      const setValue = await index.DAO();
+
+      assert.equal(setValue, daoAddress);
+    });
+
+    it('should throw if non-owner sets the DAO', async() => {
+      try {
+        await index.setDAO(daoAddress, {from: nonOwnerAccount});
+        assert(false);
+      } catch(e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+  });
+
+  describe('setLifToken', () => {
+    const tokenAddress = accounts[5];
+
+    it('should set the LifToken address', async() => {
+      await index.setLifToken(tokenAddress, {from: indexOwner});
+      const setValue = await index.LifToken();
+
+      assert.equal(setValue, tokenAddress);
+    });
+
+    it('should throw if non-owner sets the LifToken address', async() => {
+      try {
+        await index.setLifToken(tokenAddress, {from: nonOwnerAccount});
+        assert(false);
+      } catch(e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+  });
+
+  describe('registerHotel', () => {
+    const expectedIndexPos = 1; // Position of the first hotel
+
+    it('should add a hotel to the registry', async () => {
+      await index.registerHotel('name', 'desc', {from: hotelAccount});
+      const length = await index.getHotelsLength();
+
+      const allHotels = await help.jsArrayFromSolidityArray(
+        index.hotels,
+        length,
+        help.isZeroAddress
+      );
+
+      const hotelsByManager = await index.getHotelsByManager(hotelAccount);
+      const actualIndexPos = await index.hotelsIndex(allHotels[0]);
+
+      const hotel = allHotels[0];
+      const hotelByManager = hotelsByManager[0];
+
+      assert.isDefined(hotel);
+      assert.isDefined(hotelByManager);
+      assert.isFalse(help.isZeroAddress(hotel));
+      assert.isFalse(help.isZeroAddress(hotelByManager));
+
+      assert.equal(actualIndexPos, expectedIndexPos);
+      assert.equal(hotel, hotelsByManager);
+    });
+  });
+
+  describe('removeHotel', () => {
+    const expectedIndexPos = 0; // Position of the hotel in the managers array
+
+    it ('should remove a hotel', async () => {
+      await index.registerHotel('name', 'desc', {from: hotelAccount});
+      const length = await index.getHotelsLength();
+
+      let allHotels = await help.jsArrayFromSolidityArray(
+        index.hotels,
+        length,
+        help.isZeroAddress
+      );
+      const hotel = allHotels[0];
+
+      // Verify existence
+      assert.isDefined(hotel);
+      assert.isFalse(help.isZeroAddress(hotel));
+
+      // Remove and verify non-existence of hotel
+      await index.removeHotel(expectedIndexPos, {from: hotelAccount});
+
+      allHotels = await help.jsArrayFromSolidityArray(
+        index.hotels,
+        length,
+        help.isZeroAddress
+      );
+
+      const hotelsByManager = await index.getHotelsByManager(hotelAccount);
+      const hotelDeleted = help.isZeroAddress(hotelsByManager[expectedIndexPos]);
+
+      assert.equal(allHotels.length, 0);
+      assert.isTrue(hotelDeleted);
+    });
+
+    it('should throw if the hotel is not registered', async () => {
+      await index.registerHotel('name', 'desc', {from: hotelAccount});
+
+      try {
+        const invalidIndexPos = 1;
+        await index.removeHotel(invalidIndexPos, {from: hotelAccount});
+        assert(false);
+      } catch(e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+
+    it('should throw if non-owner removes', async () => {
+      await index.registerHotel('name', 'desc', {from: hotelAccount});
+
+      try {
+        await index.removeHotel(expectedIndexPos, {from: nonOwnerAccount});
+        assert(false);
+      } catch(e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+  });
+});
+


### PR DESCRIPTION
Adds unit tests for WTIndex. Makes some small changes to the Solidity:

+ Make DAO address visibility `public`
+ Expose `hotels` array's length instead of returning the public variable.

Omitted tests for `callHotel` since that method is hit a thousand times in the other tests. But this PR improves overall test coverage and provides a base for testing additions to `WTIndex`

Closes #131 
Closes #130 