### PR TITLE
modify tests for Hotel.sol to test for onlyOwner

### DIFF
--- a/test/WTIndex.js
+++ b/test/WTIndex.js
@@ -2,6 +2,7 @@ const chai = require('chai').assert;
 const help = require('./helpers/index.js');
 
 const WTIndex = artifacts.require('./WTIndex.sol');
+const WTHotel = artifacts.require('Hotel.sol');
 const Base_Interface = artifacts.require('Base_Interface.sol');
 
 contract('WTIndex', function(accounts) {
@@ -148,5 +149,35 @@ contract('WTIndex', function(accounts) {
         assert(help.isInvalidOpcodeEx(e));
       }
     });
+  });
+
+  describe('callHotel', async () => {
+    let wtHotel;
+
+    beforeEach(async () => {
+      await index.registerHotel('name', 'desc', {from: hotelAccount});
+      let address = await index.getHotelsByManager(hotelAccount);
+      wtHotel = WTHotel.at(address[0]);
+    })
+
+    it('should throw if sender address does not exist in hotelsByManager mapping', async () => {
+      const data = wtHotel.contract.editInfo.getData('newName', 'newDesc');
+      try {
+        await index.callHotel(0, data, {from: nonOwnerAccount});
+        assert(false);
+      } catch(e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    })
+
+    it('should throw if hotel index does not exist', async () => {
+      const data = wtHotel.contract.editInfo.getData('newName', 'newDesc');
+      try {
+        await index.callHotel(1, data, {from: hotelAccount});
+        assert(false);
+      } catch(e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    })
   });
 });

--- a/test/hotel.js
+++ b/test/hotel.js
@@ -486,7 +486,7 @@ contract('Hotel', function(accounts) {
         await wtHotel.callUnit(unit.address, setPriceData, {from: nonOwnerAccount});
         assert(false);
       } catch(e) {
-        assert(help.isInvalidOpcodeEx);
+        assert(help.isInvalidOpcodeEx(e));
       }
     });
 
@@ -499,7 +499,7 @@ contract('Hotel', function(accounts) {
         await wtIndex.callHotel(0, callUnitData, {from: hotelAccount});
         assert(false);
       } catch(e) {
-        assert(help.isInvalidOpcodeEx);
+        assert(help.isInvalidOpcodeEx(e));
       }
     });
   });

--- a/test/hotel.js
+++ b/test/hotel.js
@@ -58,9 +58,10 @@ contract('Hotel', function(accounts) {
 
   describe('editInfo', function(){
 
+    const newName = 'Claridges';
+    const newDescription = 'Near everything';
+
     it('should edit the hotel name and description', async function(){
-      const newName = 'Claridges';
-      const newDescription = 'Near everything';
       const data = wtHotel.contract.editInfo.getData(newName, newDescription);
       await wtIndex.callHotel(0, data, {from: hotelAccount});
       const info = await help.getHotelInfo(wtHotel);
@@ -69,13 +70,9 @@ contract('Hotel', function(accounts) {
       assert.equal(info.description, newDescription);
     });
 
-    it('should throw if non-owner edits name / description', async function(){
-      const newName = 'Claridges';
-      const newDescription = 'Near everything';
-      const data = wtHotel.contract.editInfo.getData(newName, newDescription);
-
+    it('should throw if not executed by owner', async function() {
       try {
-        await wtIndex.callHotel(0, data, {from: nonOwnerAccount});
+        await wtHotel.editInfo(newName, newDescription, {from: nonOwnerAccount});
         assert(false);
       } catch (e){
         assert(help.isInvalidOpcodeEx(e));
@@ -100,11 +97,9 @@ contract('Hotel', function(accounts) {
       assert.equal(info.country, country);
     });
 
-    it('should throw if non-owner edits address', async function(){
-      const data = wtHotel.contract.editAddress.getData(lineOne, lineTwo, zip, country);
-
+    it('should throw if not executed by owner', async function() {
       try {
-        await wtIndex.callHotel(0, data, {from: nonOwnerAccount});
+        await wtHotel.editAddress(lineOne, lineTwo, zip, country, {from: nonOwnerAccount});
         assert(false);
       } catch(e){
         assert(help.isInvalidOpcodeEx(e));
@@ -116,9 +111,9 @@ contract('Hotel', function(accounts) {
     const timezone = 2;
     const longitude = 40.426371;
     const latitude = -3.703578;
+    const { long, lat } = help.locationToUint(longitude, latitude);
 
     it('should edit the gps location', async function() {
-      const { long, lat } = help.locationToUint(longitude, latitude);
       const data = wtHotel.contract.editLocation.getData(timezone, long, lat);
       await wtIndex.callHotel(0, data, {from: hotelAccount});
       const info = await help.getHotelInfo(wtHotel);
@@ -127,12 +122,9 @@ contract('Hotel', function(accounts) {
       assert.equal(latitude, info.latitude);
     });
 
-    it('should throw if non-owner edits gps location', async function() {
-      const { long, lat } = help.locationToUint(longitude, latitude);
-      const data = wtHotel.contract.editLocation.getData(timezone, long, lat);
-
+    it('should throw if not executed by owner', async function() {
       try {
-        await wtIndex.callHotel(0, data, {from: nonOwnerAccount});
+        await wtHotel.editLocation(timezone, long, lat, {from: nonOwnerAccount});
         assert(false);
       } catch(e){
         assert(help.isInvalidOpcodeEx(e));
@@ -157,23 +149,24 @@ contract('Hotel', function(accounts) {
       assert.isDefined(info.unitTypes[typeName]);
     });
 
-    it('should throw if non-owner adds a UnitType', async function(){
-      const data = wtHotel.contract.addUnitType.getData(unitType.address);
-
-      try {
-        await wtIndex.callHotel(0, data, {from: nonOwnerAccount});
-        assert(false);
-      } catch(e){
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    });
-
     it('should throw if the added UnitType already exists', async function(){
       const data = wtHotel.contract.addUnitType.getData(unitType.address);
       await wtIndex.callHotel(0, data, {from: hotelAccount});
 
       try {
         await wtIndex.callHotel(0, data, {from: hotelAccount});
+        assert(false)
+      } catch(e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+
+    it('should throw if not executed by owner', async function() {
+      try {
+        const unitType2 = await UnitType.new(
+          wtHotel.address, web3.toHex('FANCY_ROOM'), {from: hotelAccount}
+        );
+        await wtHotel.addUnitType(unitType2.address, {from: nonOwnerAccount});
         assert(false)
       } catch(e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -206,18 +199,6 @@ contract('Hotel', function(accounts) {
       assert.isTrue(unitTypeCount.plus(1).equals(await typeInterface.totalUnits()));
     });
 
-    it('should throw if non-owner adds a Unit', async function(){
-      const unit = await Unit.new(wtHotel.address, typeNameHex, {from: hotelAccount});
-      const data = wtHotel.contract.addUnit.getData(unit.address);
-
-      try {
-        await wtIndex.callHotel(0, data, {from: nonOwnerAccount});
-        assert(false);
-      } catch (e){
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    });
-
     it('should throw if the UnitType of the Unit does not exist', async function(){
       const unknownTypeNameHex = web3.toHex('UNKNOWN');
       const unit = await Unit.new(wtHotel.address, unknownTypeNameHex, {from: hotelAccount});
@@ -230,6 +211,16 @@ contract('Hotel', function(accounts) {
         assert(help.isInvalidOpcodeEx(e));
       }
     });
+
+    it('should throw if not executed by owner', async function() {
+      const unit = await Unit.new(wtHotel.address, typeNameHex, {from: hotelAccount});
+      try {
+        await wtHotel.addUnit(unit.address, {from: nonOwnerAccount});
+        assert(false);
+      } catch (e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    })
   });
 
   describe('removeUnitType', function(){
@@ -248,17 +239,6 @@ contract('Hotel', function(accounts) {
       const info = await help.getHotelInfo(wtHotel);
 
       assert.isUndefined(info.unitTypes[typeName]);
-    });
-
-    it('should throw if non-owner attempts removal', async function() {
-      const data = wtHotel.contract.removeUnitType.getData(typeNameHex, validIndex);
-
-      try {
-        await wtIndex.callHotel(0, data, {from: nonOwnerAccount});
-        assert(false);
-      } catch (e) {
-        assert(help.isInvalidOpcodeEx(e));
-      }
     });
 
     it('should throw if the unit type to be removed does not exist', async function(){
@@ -284,6 +264,15 @@ contract('Hotel', function(accounts) {
         assert(help.isInvalidOpcodeEx(e));
       }
     });
+
+    it('should throw if not executed by owner', async function() {
+      try {
+        await wtHotel.removeUnitType(typeNameHex, validIndex, {from: nonOwnerAccount});
+        assert(false);
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    })
   });
 
   describe('removeUnit', function(){
@@ -307,16 +296,14 @@ contract('Hotel', function(accounts) {
       assert.isTrue(unitTypeCount.minus(1).equals(await typeInterface.totalUnits()));
     });
 
-    it('should throw if non-owner removes unit', async function() {
-      const data = wtHotel.contract.removeUnit.getData(unit.address);
-
+    it('should throw if not executed by owner', async function() {
       try {
-        await wtIndex.callHotel(0, data, {from: nonOwnerAccount});
+        await wtHotel.removeUnit(unit.address, {from: nonOwnerAccount});
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
       }
-    });
+    })
   });
 
   describe('changeUnitType', function(){
@@ -351,17 +338,6 @@ contract('Hotel', function(accounts) {
       }
     });
 
-    it('should throw if a non-owner changes the UnitType', async function(){
-      const data = wtHotel.contract.changeUnitType.getData(hexBasic, unitTypeReplacement.address);
-
-      try {
-        await wtIndex.callHotel(0, data, {from: nonOwnerAccount});
-        assert(false);
-      } catch (e) {
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    });
-
     it('should throw if the UnitType does not exist', async function(){
       const hexUnknown = web3.toHex('UNKNOWN');
       const data = wtHotel.contract.changeUnitType.getData(hexUnknown, unitTypeReplacement.address);
@@ -373,6 +349,15 @@ contract('Hotel', function(accounts) {
         assert(help.isInvalidOpcodeEx(e));
       }
     });
+
+    it('should throw if not executed by owner', async function() {
+      try {
+        await wtHotel.changeUnitType(hexBasic, unitTypeReplacement.address, {from: nonOwnerAccount});
+        assert(false)
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    })
   });
 
   describe('callUnitType', function(){
@@ -437,18 +422,6 @@ contract('Hotel', function(accounts) {
       assert.equal(edits.price, price);
     });
 
-    it('should throw if non-owner executes the call', async function(){
-      const addAmenityData = typeInterface.contract.addAmenity.getData(amenityNumber);
-      const callUnitTypeData = wtHotel.contract.callUnitType.getData(typeNameHex, addAmenityData);
-
-      try {
-        await wtIndex.callHotel(0, callUnitTypeData, {from: nonOwnerAccount});
-        assert(false);
-      } catch (e) {
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    });
-
     it('should throw if the hotel does not have the UnitType being called', async function(){
       const hexUnknown = web3.toHex('UNKNOWN_ROOM');
       const unknownUnitType = await UnitType.new(wtHotel.address, hexUnknown, {from: hotelAccount});
@@ -467,6 +440,16 @@ contract('Hotel', function(accounts) {
 
     // Not much throwing on UnitType except OnlyOwner which already throws.
     it.skip('should throw if the call to the UnitType returns false');
+
+    it('should throw if not executed by owner', async function() {
+      const addAmenityData = typeInterface.contract.addAmenity.getData(amenityNumber);
+      try {
+        await wtHotel.callUnitType(typeNameHex, addAmenityData, {from: nonOwnerAccount})
+        assert(false);
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    })
   });
 
   describe('callUnit', function(){
@@ -497,18 +480,6 @@ contract('Hotel', function(accounts) {
       assert(help.isZeroAddress(reservation[2]));
     });
 
-    it('should fail if a non-owner calls the Unit', async function(){
-      setPriceData = unitInterface.contract.setSpecialPrice.getData(price, fromDay, daysAmount);
-      callUnitData = wtHotel.contract.callUnit.getData(unit.address, setPriceData);
-
-      try {
-        await wtIndex.callHotel(0, callUnitData, {from: nonOwnerAccount});
-        assert(false);
-      } catch(e) {
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    });
-
     it('should fail if the Unit is not listed in the Hotels index of Units', async function(){
       const unknownUnit = await Unit.new(wtHotel.address, typeNameHex, {from: hotelAccount});
       setPriceData = unitInterface.contract.setSpecialPrice.getData(price, fromDay, daysAmount);
@@ -521,5 +492,15 @@ contract('Hotel', function(accounts) {
         assert(help.isInvalidOpcodeEx);
       }
     });
+
+    it('should throw if not executed by owner', async function() {
+      setPriceData = unitInterface.contract.setSpecialPrice.getData(price, fromDay, daysAmount);
+      try {
+        await wtHotel.callUnit(unit.address, setPriceData, {from: nonOwnerAccount});
+        assert(false);
+      } catch(e) {
+        assert(help.isInvalidOpcodeEx);
+      }
+    })  
   });
 });

--- a/test/hotel.js
+++ b/test/hotel.js
@@ -149,24 +149,24 @@ contract('Hotel', function(accounts) {
       assert.isDefined(info.unitTypes[typeName]);
     });
 
-    it('should throw if the added UnitType already exists', async function(){
-      const data = wtHotel.contract.addUnitType.getData(unitType.address);
-      await wtIndex.callHotel(0, data, {from: hotelAccount});
-
-      try {
-        await wtIndex.callHotel(0, data, {from: hotelAccount});
-        assert(false)
-      } catch(e) {
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    });
-
     it('should throw if not executed by owner', async function() {
       try {
         const unitType2 = await UnitType.new(
           wtHotel.address, web3.toHex('FANCY_ROOM'), {from: hotelAccount}
         );
         await wtHotel.addUnitType(unitType2.address, {from: nonOwnerAccount});
+        assert(false)
+      } catch(e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+
+    it('should throw if the added UnitType already exists', async function(){
+      const data = wtHotel.contract.addUnitType.getData(unitType.address);
+      await wtIndex.callHotel(0, data, {from: hotelAccount});
+
+      try {
+        await wtIndex.callHotel(0, data, {from: hotelAccount});
         assert(false)
       } catch(e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -198,6 +198,16 @@ contract('Hotel', function(accounts) {
       assert.isDefined(info.units[unit.address]);
       assert.isTrue(unitTypeCount.plus(1).equals(await typeInterface.totalUnits()));
     });
+    
+    it('should throw if not executed by owner', async function() {
+      const unit = await Unit.new(wtHotel.address, typeNameHex, {from: hotelAccount});
+      try {
+        await wtHotel.addUnit(unit.address, {from: nonOwnerAccount});
+        assert(false);
+      } catch (e){
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
 
     it('should throw if the UnitType of the Unit does not exist', async function(){
       const unknownTypeNameHex = web3.toHex('UNKNOWN');
@@ -211,16 +221,6 @@ contract('Hotel', function(accounts) {
         assert(help.isInvalidOpcodeEx(e));
       }
     });
-
-    it('should throw if not executed by owner', async function() {
-      const unit = await Unit.new(wtHotel.address, typeNameHex, {from: hotelAccount});
-      try {
-        await wtHotel.addUnit(unit.address, {from: nonOwnerAccount});
-        assert(false);
-      } catch (e){
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    })
   });
 
   describe('removeUnitType', function(){
@@ -239,6 +239,15 @@ contract('Hotel', function(accounts) {
       const info = await help.getHotelInfo(wtHotel);
 
       assert.isUndefined(info.unitTypes[typeName]);
+    });
+
+    it('should throw if not executed by owner', async function() {
+      try {
+        await wtHotel.removeUnitType(typeNameHex, validIndex, {from: nonOwnerAccount});
+        assert(false);
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
     });
 
     it('should throw if the unit type to be removed does not exist', async function(){
@@ -264,15 +273,6 @@ contract('Hotel', function(accounts) {
         assert(help.isInvalidOpcodeEx(e));
       }
     });
-
-    it('should throw if not executed by owner', async function() {
-      try {
-        await wtHotel.removeUnitType(typeNameHex, validIndex, {from: nonOwnerAccount});
-        assert(false);
-      } catch (e) {
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    })
   });
 
   describe('removeUnit', function(){
@@ -338,6 +338,15 @@ contract('Hotel', function(accounts) {
       }
     });
 
+    it('should throw if not executed by owner', async function() {
+      try {
+        await wtHotel.changeUnitType(hexBasic, unitTypeReplacement.address, {from: nonOwnerAccount});
+        assert(false)
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+
     it('should throw if the UnitType does not exist', async function(){
       const hexUnknown = web3.toHex('UNKNOWN');
       const data = wtHotel.contract.changeUnitType.getData(hexUnknown, unitTypeReplacement.address);
@@ -349,15 +358,6 @@ contract('Hotel', function(accounts) {
         assert(help.isInvalidOpcodeEx(e));
       }
     });
-
-    it('should throw if not executed by owner', async function() {
-      try {
-        await wtHotel.changeUnitType(hexBasic, unitTypeReplacement.address, {from: nonOwnerAccount});
-        assert(false)
-      } catch (e) {
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    })
   });
 
   describe('callUnitType', function(){
@@ -421,6 +421,16 @@ contract('Hotel', function(accounts) {
       assert.equal(edits.maxGuests, maxGuests);
       assert.equal(edits.price, price);
     });
+    
+    it('should throw if not executed by owner', async function() {
+      const addAmenityData = typeInterface.contract.addAmenity.getData(amenityNumber);
+      try {
+        await wtHotel.callUnitType(typeNameHex, addAmenityData, {from: nonOwnerAccount})
+        assert(false);
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
 
     it('should throw if the hotel does not have the UnitType being called', async function(){
       const hexUnknown = web3.toHex('UNKNOWN_ROOM');
@@ -440,16 +450,6 @@ contract('Hotel', function(accounts) {
 
     // Not much throwing on UnitType except OnlyOwner which already throws.
     it.skip('should throw if the call to the UnitType returns false');
-
-    it('should throw if not executed by owner', async function() {
-      const addAmenityData = typeInterface.contract.addAmenity.getData(amenityNumber);
-      try {
-        await wtHotel.callUnitType(typeNameHex, addAmenityData, {from: nonOwnerAccount})
-        assert(false);
-      } catch (e) {
-        assert(help.isInvalidOpcodeEx(e));
-      }
-    })
   });
 
   describe('callUnit', function(){
@@ -479,6 +479,16 @@ contract('Hotel', function(accounts) {
       assert.equal(reservation[0], price);
       assert(help.isZeroAddress(reservation[2]));
     });
+    
+    it('should throw if not executed by owner', async function() {
+      setPriceData = unitInterface.contract.setSpecialPrice.getData(price, fromDay, daysAmount);
+      try {
+        await wtHotel.callUnit(unit.address, setPriceData, {from: nonOwnerAccount});
+        assert(false);
+      } catch(e) {
+        assert(help.isInvalidOpcodeEx);
+      }
+    });
 
     it('should fail if the Unit is not listed in the Hotels index of Units', async function(){
       const unknownUnit = await Unit.new(wtHotel.address, typeNameHex, {from: hotelAccount});
@@ -492,15 +502,5 @@ contract('Hotel', function(accounts) {
         assert(help.isInvalidOpcodeEx);
       }
     });
-
-    it('should throw if not executed by owner', async function() {
-      setPriceData = unitInterface.contract.setSpecialPrice.getData(price, fromDay, daysAmount);
-      try {
-        await wtHotel.callUnit(unit.address, setPriceData, {from: nonOwnerAccount});
-        assert(false);
-      } catch(e) {
-        assert(help.isInvalidOpcodeEx);
-      }
-    })  
   });
 });


### PR DESCRIPTION
The tests for non-owner execution were using the `callHotel` function in `WTIndex.sol`, so they were actually testing that `msg.sender` exists in the `hotelsByManager` mapping. This commit changes the tests in `hotel.js` to execute functions directly on the `Hotel.sol` contract with a non-owner, in order to test that it's public functions are protected by the `onlyOwner` modifier.

This commit also adds tests to `WTIndex.js` that test the `callHotel` function directly.