### PR TITLE
Add solidity docs generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ node_modules
 # Coverage artifacts
 coverage
 coverage.json
-scTopics
+.flattened
 allFiredEvents

--- a/contracts/AsyncCall.sol
+++ b/contracts/AsyncCall.sol
@@ -105,9 +105,9 @@ contract AsyncCall is Ownable {
 
     @param msgDataHash The hash of the pending call
 
-    @return bytes The public call data
+    @return { "_callData": "The public call data" }
   */
-  function getPublicCallData(bytes32 msgDataHash) constant returns (bytes) {
+  function getPublicCallData(bytes32 msgDataHash) constant returns (bytes _callData) {
     return pendingCalls[msgDataHash].callData;
   }
 

--- a/contracts/Images.sol
+++ b/contracts/Images.sol
@@ -39,9 +39,9 @@ contract Images is Ownable {
   /**
      @dev `getImagesLength` get the length of the `images` array
 
-     @return uint Length of the `images` array
+     @return { "_length": "Length of the `images` array" }
    */
-  function getImagesLength() constant returns (uint) {
+  function getImagesLength() constant returns (uint _length) {
     return images.length;
   }
 

--- a/contracts/WTContracts.sol
+++ b/contracts/WTContracts.sol
@@ -93,11 +93,15 @@ contract WTContracts is Ownable {
      @dev `getByAddr` get the info of a registered contract by address
 
      @param _addr The registered contract's address
-     returns {name, address, url, version} The contract's information
+     @return {
+      "_name": "Contract name or empty string",
+      "_address": "Contract address or zero address",
+      "_version": "Contract version or empty string"
+    }
    */
   function getByAddr(
     address _addr
-  ) constant returns(string, address, string){
+  ) constant returns(string _name, address _address, string _version) {
     if (addrs[_addr] > 0)
       return (
         contracts[ addrs[_addr] ].name,
@@ -112,11 +116,15 @@ contract WTContracts is Ownable {
      @dev `getByName` get the info of a registered contract by name
 
      @param _name The registered contract's name
-     returns {name, address, url, version} The contract's information
+     @return {
+      "_contractName": "Contract name or empty string",
+      "_address": "Contract address or zero address",
+      "_version": "Contract version or empty string"
+    }
    */
   function getByName(
     string _name
-  ) constant returns(string, address, string){
+  ) constant returns(string _contractName, address _address, string _version) {
     if (names[_name] > 0)
       return (
         contracts[ names[_name] ].name,

--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -104,27 +104,27 @@ contract WTIndex is Ownable {
   /**
      @dev `getHotelsLength` get the length of the `hotels` array
 
-     @return uint Length of the `hotels` array
+     @return { "_length" : "Length of the `hotels` array" }
    */
-  function getHotelsLength() constant returns (uint) {
+  function getHotelsLength() constant returns (uint _length) {
     return hotels.length;
   }
 
   /**
      @dev `getHotels` get `hotels` array
 
-     @return address[] `hotels` array
+     @return { "_hotels" : "The addresses of all `Hotel` contracts" }
    */
-  function getHotels() constant returns (address[]) {
+  function getHotels() constant returns (address[] _hotels) {
     return hotels;
   }
 
   /**
      @dev `getHotelsByManager` get all the hotels belonging to one manager
 
-     returns The addresses of `Hotel` contracts that belong to one manager
+     @return { "_hotels" : "The addresses of `Hotel` contracts that belong to one manager" }
    */
-	function getHotelsByManager(address owner) constant returns(address[]){
+	function getHotelsByManager(address owner) constant returns(address[] _hotels) {
 		return hotelsByManager[owner];
 	}
 

--- a/contracts/hotel/Hotel.sol
+++ b/contracts/hotel/Hotel.sol
@@ -283,13 +283,13 @@ contract Hotel is AsyncCall, Images, Destructible {
      @param fromDay The starting date of the period of days to book
      @param daysAmount The amount of days in the period
 
-     @return uint256 The total cost of the booking in the custom currency
+     @return { "_totalCost": "The total cost of the booking in the custom currency" }
    */
   function getCost(
     address unitAddress,
     uint256 fromDay,
     uint256 daysAmount
-  ) constant returns(uint256) {
+  ) constant returns(uint256 _totalCost) {
     uint256 toDay = fromDay+daysAmount;
     uint256 totalCost = 0;
     uint256 defaultPrice = UnitType_Interface(unitTypes[Unit_Interface(unitAddress).unitType()]).defaultPrice();
@@ -312,13 +312,13 @@ contract Hotel is AsyncCall, Images, Destructible {
      @param fromDay The starting date of the period of days to book
      @param daysAmount The amount of days in the period
 
-     @return uint256 The total cost of the booking in Lif
+     @return { "_totalCost": "The total cost of the booking in Lif" }
    */
   function getLifCost(
     address unitAddress,
     uint256 fromDay,
     uint256 daysAmount
-  ) constant returns(uint256) {
+  ) constant returns(uint256 _totalCost) {
     uint256 toDay = fromDay+daysAmount;
     uint256 totalCost = 0;
     uint256 defaultLifPrice = UnitType_Interface(unitTypes[Unit_Interface(unitAddress).unitType()]).defaultLifPrice();
@@ -340,36 +340,36 @@ contract Hotel is AsyncCall, Images, Destructible {
 
      @param unitType The type of the unit
 
-     @return address Address of the `UnitType` contract
+     @return { "_unitTypeAddress": "Address of the `UnitType` contract"}
    */
-  function getUnitType(bytes32 unitType) constant returns (address) {
+  function getUnitType(bytes32 unitType) constant returns (address _unitTypeAddress) {
     return unitTypes[unitType];
   }
 
   /**
      @dev `getUnitTypeNames` get the names of all the unitTypes
 
-     @return bytes32[] Names of all the unit types
+     @return { "_unitTypeNames": "Names of all the unit types" }
    */
-  function getUnitTypeNames() constant returns (bytes32[]) {
+  function getUnitTypeNames() constant returns (bytes32[] _unitTypeNames) {
     return unitTypeNames;
   }
 
   /**
      @dev `getUnitsLength` get the length of the `units` array
 
-     @return uint Length of the `units` array
+     @return { "_length": "Length of the `units` array" }
    */
-  function getUnitsLength() constant returns (uint) {
+  function getUnitsLength() constant returns (uint _length) {
     return units.length;
   }
 
   /**
      @dev `getUnits` get the `units` array
 
-     @return address[] the `units` array
+     @return { "_units": "the `units` array" }
    */
-  function getUnits() constant returns (address[]) {
+  function getUnits() constant returns (address[] _units) {
     return units;
   }
 

--- a/contracts/hotel/Unit.sol
+++ b/contracts/hotel/Unit.sol
@@ -96,13 +96,13 @@ contract Unit is Destructible {
      @param fromDay The starting day of the period of days to book
      @param daysAmount The amount of days in the booking period
 
-     @return bool Whether the booking was successful or not
+     @return { "_bookingResult": "Whether the booking was successful or not" }
    */
   function book(
     address from,
     uint256 fromDay,
     uint256 daysAmount
-  ) onlyOwner() returns(bool) {
+  ) onlyOwner() returns(bool _bookingResult) {
     require(isFutureDay(fromDay));
     require(active);
     uint256 toDay = fromDay+daysAmount;
@@ -123,14 +123,15 @@ contract Unit is Destructible {
 
      @param day The number of days after 01-01-1970
 
-     @return uint256 The price of the day in the custom currency, 0 if default price
-     @return uint256 The price of the day in Líf, 0 if default price
-     @return address The address of the owner of the reservation
-     returns 0x0 if its available
+     @return {
+       "_specialPrice": "The price of the day in the custom currency, 0 if default price",
+       "_specialLifPrice": "The price of the day in Líf, 0 if default price",
+       "_bookedBy": "The address of the owner of the reservation, returns 0x0 if its available"
+     }
    */
   function getReservation(
     uint256 day
-  ) constant returns(uint256, uint256, address) {
+  ) constant returns(uint256 _specialPrice, uint256 _specialLifPrice, address _bookedBy) {
     return (
       reservations[day].specialPrice,
       reservations[day].specialLifPrice,
@@ -144,12 +145,12 @@ contract Unit is Destructible {
      @param fromDay The starting date of the period of days to book
      @param daysAmount The amount of days in the period
 
-     @return uint256 The total cost of the booking in the custom currency
+     @return { "_totalCost": "The total cost of the booking in the custom currency" }
    */
   /* function getCost(
     uint256 fromDay,
     uint256 daysAmount
-  ) constant returns(uint256) {
+  ) constant returns(uint256 _totalCost) {
     uint256 toDay = fromDay+daysAmount;
     uint256 totalCost = 0;
 
@@ -170,12 +171,12 @@ contract Unit is Destructible {
      @param fromDay The starting date of the period of days to book
      @param daysAmount The amount of days in the period
 
-     @return uint256 The total cost of the booking in Lif
+     @return {"_totalCost": "The total cost of the booking in Lif" }
    */
   /* function getLifCost(
     uint256 fromDay,
     uint256 daysAmount
-  ) constant returns(uint256) {
+  ) constant returns(uint256 _totalCost) {
     uint256 toDay = fromDay+daysAmount;
     uint256 totalCost = 0;
 
@@ -195,9 +196,9 @@ contract Unit is Destructible {
 
      @param time The number of days after 01-01-1970
 
-     @return bool If the timestamp is today or in the future
+     @return { "_isFutureDay": "If the timestamp is today or in the future" }
    */
-  function isFutureDay(uint256 time) internal returns (bool) {
+  function isFutureDay(uint256 time) internal returns (bool _isFutureDay) {
     return !(now / 86400 > time);
   }
 

--- a/contracts/hotel/UnitType.sol
+++ b/contracts/hotel/UnitType.sol
@@ -26,7 +26,7 @@ contract UnitType is Destructible, Images {
   // The description of the unit type
   string description;
 
-  // The minimun and maximun amount of guests
+  // The minimun and maximum amount of guests
   uint minGuests;
   uint maxGuests;
 
@@ -59,7 +59,7 @@ contract UnitType is Destructible, Images {
      min/max guests and base price
 
      @param _minGuests The minimun amount of guests allowed
-     @param _maxGuests The maximun amount of guests allowed
+     @param _maxGuests The maximum amount of guests allowed
      @param _description The new description
    */
   function edit(
@@ -139,21 +139,23 @@ contract UnitType is Destructible, Images {
   /**
      @dev `GetInfo` get the information of the unit
 
-     @return string The description of the unit type
-     @return uint The minimun amount guests
-     @return uint The maximun amount guests
-     @return uint The default fiat price
+     @return {
+      "_description": "The description of the unit type",
+      "_minGuests": "The minimun amount guests",
+      "_maxGuests": "The maximum amount guests",
+      "_defaultPrice": "The default fiat price"
+    }
    */
-  function getInfo() constant returns(string, uint, uint, uint) {
+  function getInfo() constant returns(string _description, uint _minGuests, uint _maxGuests, uint _defaultPrice) {
     return (description, minGuests, maxGuests, defaultPrice);
   }
 
   /**
      @dev `getAmenities` get the amenities ids
 
-     @return uint[] Array of all the amenities ids in the unit type
+     @return {"_amenities": "Array of all the amenities ids in the unit type" }
    */
-  function getAmenities() constant returns(uint[]) {
+  function getAmenities() constant returns(uint[] _amenities) {
     return (amenities);
   }
 

--- a/docs/AsyncCall.md
+++ b/docs/AsyncCall.md
@@ -1,0 +1,167 @@
+* [AsyncCall](#asynccall)
+  * [beginCall](#function-begincall)
+  * [pendingCalls](#function-pendingcalls)
+  * [continueCall](#function-continuecall)
+  * [changeConfirmation](#function-changeconfirmation)
+  * [version](#function-version)
+  * [owner](#function-owner)
+  * [waitConfirmation](#function-waitconfirmation)
+  * [getPublicCallData](#function-getpubliccalldata)
+  * [contractType](#function-contracttype)
+  * [transferOwnership](#function-transferownership)
+  * [CallStarted](#event-callstarted)
+  * [CallFinish](#event-callfinish)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# AsyncCall
+
+
+## *function* beginCall
+
+AsyncCall.beginCall(publicCallData, privateData) `nonpayable` `203eaf27`
+
+> `beginCall` requests the execution of a call by the contract
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes* | publicCallData | The call data to be executed |
+| *bytes* | privateData | The extra, encrypted data stored as a parameter returns true if the call was requested succesfully |
+
+
+## *function* pendingCalls
+
+AsyncCall.pendingCalls() `view` `32fdd45c`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
+
+
+## *function* continueCall
+
+AsyncCall.continueCall(msgDataHash) `nonpayable` `411f2351`
+
+> `continueCall` allows the owner to approve the execution of a call
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | msgDataHash | The hash of the call to be executed |
+
+
+## *function* changeConfirmation
+
+AsyncCall.changeConfirmation(_waitConfirmation) `nonpayable` `44f5484a`
+
+> `changeConfirmation` allows the owner of the contract to switch the `waitConfirmation` value
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* | _waitConfirmation | The new `waitConfirmation` value |
+
+
+## *function* version
+
+AsyncCall.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* owner
+
+AsyncCall.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* waitConfirmation
+
+AsyncCall.waitConfirmation() `view` `ac72bb98`
+
+
+
+
+
+## *function* getPublicCallData
+
+AsyncCall.getPublicCallData(msgDataHash) `view` `acc36826`
+
+> `getPublicCallData` returns the data to be executed of a pending call
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | msgDataHash | The hash of the pending call |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes* | _callData | The public call data |
+
+## *function* contractType
+
+AsyncCall.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* transferOwnership
+
+AsyncCall.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+## *event* CallStarted
+
+AsyncCall.CallStarted(from, dataHash) `5ec33322`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *bytes32* | dataHash | not indexed |
+
+## *event* CallFinish
+
+AsyncCall.CallFinish(from, dataHash) `b2be3874`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *bytes32* | dataHash | not indexed |
+
+## *event* OwnershipTransferred
+
+AsyncCall.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/AsyncCall_Interface.md
+++ b/docs/AsyncCall_Interface.md
@@ -1,0 +1,127 @@
+* [AsyncCall_Interface](#asynccall_interface)
+  * [beginCall](#function-begincall)
+  * [pendingCalls](#function-pendingcalls)
+  * [continueCall](#function-continuecall)
+  * [changeConfirmation](#function-changeconfirmation)
+  * [owner](#function-owner)
+  * [waitConfirmation](#function-waitconfirmation)
+  * [transferOwnership](#function-transferownership)
+  * [CallStarted](#event-callstarted)
+  * [CallFinish](#event-callfinish)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# AsyncCall_Interface
+
+
+## *function* beginCall
+
+AsyncCall_Interface.beginCall(publicCallData, privateData) `nonpayable` `203eaf27`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes* | publicCallData | undefined |
+| *bytes* | privateData | undefined |
+
+
+## *function* pendingCalls
+
+AsyncCall_Interface.pendingCalls() `view` `32fdd45c`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
+
+
+## *function* continueCall
+
+AsyncCall_Interface.continueCall(msgDataHash) `nonpayable` `411f2351`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | msgDataHash | undefined |
+
+
+## *function* changeConfirmation
+
+AsyncCall_Interface.changeConfirmation(_waitConfirmation) `nonpayable` `44f5484a`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* | _waitConfirmation | undefined |
+
+
+## *function* owner
+
+AsyncCall_Interface.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* waitConfirmation
+
+AsyncCall_Interface.waitConfirmation() `view` `ac72bb98`
+
+
+
+
+
+## *function* transferOwnership
+
+AsyncCall_Interface.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+## *event* CallStarted
+
+AsyncCall_Interface.CallStarted(from, dataHash) `5ec33322`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *bytes32* | dataHash | not indexed |
+
+## *event* CallFinish
+
+AsyncCall_Interface.CallFinish(from, dataHash) `b2be3874`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *bytes32* | dataHash | not indexed |
+
+## *event* OwnershipTransferred
+
+AsyncCall_Interface.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/Base_Interface.md
+++ b/docs/Base_Interface.md
@@ -1,0 +1,24 @@
+* [Base_Interface](#base_interface)
+  * [version](#function-version)
+  * [contractType](#function-contracttype)
+
+# Base_Interface
+
+
+## *function* version
+
+Base_Interface.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* contractType
+
+Base_Interface.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+---

--- a/docs/Hotel.md
+++ b/docs/Hotel.md
@@ -1,0 +1,689 @@
+* [Hotel](#hotel)
+  * [zip](#function-zip)
+  * [getUnits](#function-getunits)
+  * [name](#function-name)
+  * [editInfo](#function-editinfo)
+  * [editLocation](#function-editlocation)
+  * [addImage](#function-addimage)
+  * [callUnit](#function-callunit)
+  * [beginCall](#function-begincall)
+  * [getLifCost](#function-getlifcost)
+  * [unitTypeNames](#function-unittypenames)
+  * [lineOne](#function-lineone)
+  * [unitTypes](#function-unittypes)
+  * [getUnitTypeNames](#function-getunittypenames)
+  * [created](#function-created)
+  * [pendingCalls](#function-pendingcalls)
+  * [changeUnitType](#function-changeunittype)
+  * [continueCall](#function-continuecall)
+  * [changeConfirmation](#function-changeconfirmation)
+  * [manager](#function-manager)
+  * [latitude](#function-latitude)
+  * [version](#function-version)
+  * [longitude](#function-longitude)
+  * [unitsIndex](#function-unitsindex)
+  * [getImagesLength](#function-getimageslength)
+  * [getCost](#function-getcost)
+  * [bookWithLif](#function-bookwithlif)
+  * [description](#function-description)
+  * [getUnitType](#function-getunittype)
+  * [destroy](#function-destroy)
+  * [images](#function-images)
+  * [getUnitsLength](#function-getunitslength)
+  * [removeImage](#function-removeimage)
+  * [owner](#function-owner)
+  * [addUnit](#function-addunit)
+  * [waitConfirmation](#function-waitconfirmation)
+  * [getPublicCallData](#function-getpubliccalldata)
+  * [book](#function-book)
+  * [timezone](#function-timezone)
+  * [contractType](#function-contracttype)
+  * [country](#function-country)
+  * [callUnitType](#function-callunittype)
+  * [addUnitType](#function-addunittype)
+  * [units](#function-units)
+  * [deleteUnit](#function-deleteunit)
+  * [deleteUnitType](#function-deleteunittype)
+  * [lineTwo](#function-linetwo)
+  * [transferOwnership](#function-transferownership)
+  * [destroyAndSend](#function-destroyandsend)
+  * [Book](#event-book)
+  * [CallStarted](#event-callstarted)
+  * [CallFinish](#event-callfinish)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# Hotel
+
+
+## *function* zip
+
+Hotel.zip() `view` `00919055`
+
+
+
+
+
+## *function* getUnits
+
+Hotel.getUnits() `view` `027aa9f5`
+
+> `getUnits` get the `units` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address[]* | _units | the `units` array |
+
+## *function* name
+
+Hotel.name() `view` `06fdde03`
+
+
+
+
+
+## *function* editInfo
+
+Hotel.editInfo(_name, _description) `nonpayable` `0b0d3ca2`
+
+> `editInfo` allows the owner of the contract to change the hotel's main information
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _name | The new name of the hotel |
+| *string* | _description | The new description of the hotel |
+
+
+## *function* editLocation
+
+Hotel.editLocation(_lineOne, _lineTwo, _zip, _country, _timezone, _longitude, _latitude) `nonpayable` `15e9dfde`
+
+> `editLocation` allows the owner of the contract to change the hotel's address and geolocation
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _lineOne | The new main address of the hotel |
+| *string* | _lineTwo | The new second address of the hotel |
+| *string* | _zip | The new zip code of the hotel |
+| *bytes2* | _country | The new ISO3166-1 Alpha2 country code of the hotel |
+| *string* | _timezone | The new tz database timezone of the hotel |
+| *uint256* | _longitude | The new longitude value of the location of the hotel |
+| *uint256* | _latitude | The new longitude value of the latitude of the hotel |
+
+
+## *function* addImage
+
+Hotel.addImage(url) `nonpayable` `166f1779`
+
+> `addImage` allows the owner to add an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | url | The url of the image |
+
+
+## *function* callUnit
+
+Hotel.callUnit(unitAddress, data) `nonpayable` `1c4e4d46`
+
+> `callUnit` allows the owner to call a unit
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | The address of the `Unit` contract |
+| *bytes* | data | The data of the call to execute on the `Unit` contract |
+
+
+## *function* beginCall
+
+Hotel.beginCall(publicCallData, privateData) `nonpayable` `203eaf27`
+
+> `beginCall` requests the execution of a call by the contract
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes* | publicCallData | The call data to be executed |
+| *bytes* | privateData | The extra, encrypted data stored as a parameter returns true if the call was requested succesfully |
+
+
+## *function* getLifCost
+
+Hotel.getLifCost(unitAddress, fromDay, daysAmount) `view` `25820f61`
+
+> `getLifCost` calculates the cost of renting the Unit for the given dates
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | undefined |
+| *uint256* | fromDay | The starting date of the period of days to book |
+| *uint256* | daysAmount | The amount of days in the period |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _totalCost | The total cost of the booking in Lif |
+
+## *function* unitTypeNames
+
+Hotel.unitTypeNames() `view` `28ef6b93`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* lineOne
+
+Hotel.lineOne() `view` `2a323572`
+
+
+
+
+
+## *function* unitTypes
+
+Hotel.unitTypes() `view` `2bb03f6e`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
+
+
+## *function* getUnitTypeNames
+
+Hotel.getUnitTypeNames() `view` `2db25a38`
+
+> `getUnitTypeNames` get the names of all the unitTypes
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32[]* | _unitTypeNames | Names of all the unit types |
+
+## *function* created
+
+Hotel.created() `view` `325a19f1`
+
+
+
+
+
+## *function* pendingCalls
+
+Hotel.pendingCalls() `view` `32fdd45c`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
+
+
+## *function* changeUnitType
+
+Hotel.changeUnitType(unitType, newAddr) `nonpayable` `37844767`
+
+> `changeUnitType` allows the owner to change a unit type
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | unitType | The type of unit |
+| *address* | newAddr | The new address of the `UnitType` contract |
+
+
+## *function* continueCall
+
+Hotel.continueCall(msgDataHash) `nonpayable` `411f2351`
+
+> `continueCall` allows the owner to approve the execution of a call
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | msgDataHash | The hash of the call to be executed |
+
+
+## *function* changeConfirmation
+
+Hotel.changeConfirmation(_waitConfirmation) `nonpayable` `44f5484a`
+
+> `changeConfirmation` allows the owner of the contract to switch the `waitConfirmation` value
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* | _waitConfirmation | The new `waitConfirmation` value |
+
+
+## *function* manager
+
+Hotel.manager() `view` `481c6a75`
+
+
+
+
+
+## *function* latitude
+
+Hotel.latitude() `view` `4fd7d76a`
+
+
+
+
+
+## *function* version
+
+Hotel.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* longitude
+
+Hotel.longitude() `view` `589af69c`
+
+
+
+
+
+## *function* unitsIndex
+
+Hotel.unitsIndex() `view` `5edad458`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
+
+
+## *function* getImagesLength
+
+Hotel.getImagesLength() `view` `60839bd8`
+
+> `getImagesLength` get the length of the `images` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _length | Length of the `images` array |
+
+## *function* getCost
+
+Hotel.getCost(unitAddress, fromDay, daysAmount) `view` `62a966b0`
+
+> `getCost` calculates the cost of renting the Unit for the given dates
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | undefined |
+| *uint256* | fromDay | The starting date of the period of days to book |
+| *uint256* | daysAmount | The amount of days in the period |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _totalCost | The total cost of the booking in the custom currency |
+
+## *function* bookWithLif
+
+Hotel.bookWithLif(unitAddress, from, fromDay, daysAmount) `nonpayable` `676e0079`
+
+> `bookWithLif` allows the contract to execute a book function itself
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | The address of the `Unit` contract |
+| *address* | from | The address of the opener of the reservation |
+| *uint256* | fromDay | The starting day of the period of days to book |
+| *uint256* | daysAmount | The amount of days in the booking period |
+
+
+## *function* description
+
+Hotel.description() `view` `7284e416`
+
+
+
+
+
+## *function* getUnitType
+
+Hotel.getUnitType(unitType) `view` `7e1d63c3`
+
+> `getUnitType` get the address of a unit type
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | unitType | The type of the unit |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _unitTypeAddress | Address of the `UnitType` contract |
+
+## *function* destroy
+
+Hotel.destroy() `nonpayable` `83197ef0`
+
+> 'destroy' allows the owner to delete the Hotel and all of its Units and UnitTypes
+
+
+
+
+## *function* images
+
+Hotel.images() `view` `84856482`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* getUnitsLength
+
+Hotel.getUnitsLength() `view` `8ab7cbfa`
+
+> `getUnitsLength` get the length of the `units` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _length | Length of the `units` array |
+
+## *function* removeImage
+
+Hotel.removeImage(index) `nonpayable` `8b25261f`
+
+> `removeImage` allows the owner to remove an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | index | The image's index in the `images` array |
+
+
+## *function* owner
+
+Hotel.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* addUnit
+
+Hotel.addUnit(unit) `nonpayable` `a9f7f247`
+
+> `addUnit` allows the owner to add a new unit to the inventory
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unit | The address of the `Unit` contract |
+
+
+## *function* waitConfirmation
+
+Hotel.waitConfirmation() `view` `ac72bb98`
+
+
+
+
+
+## *function* getPublicCallData
+
+Hotel.getPublicCallData(msgDataHash) `view` `acc36826`
+
+> `getPublicCallData` returns the data to be executed of a pending call
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | msgDataHash | The hash of the pending call |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes* | _callData | The public call data |
+
+## *function* book
+
+Hotel.book(unitAddress, from, fromDay, daysAmount) `nonpayable` `b9a527b4`
+
+> `book` allows the contract to execute a book function itself
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | The address of the `Unit` contract |
+| *address* | from | The address of the opener of the reservation |
+| *uint256* | fromDay | The starting day of the period of days to book |
+| *uint256* | daysAmount | The amount of days in the booking period |
+
+
+## *function* timezone
+
+Hotel.timezone() `view` `c4148fe5`
+
+
+
+
+
+## *function* contractType
+
+Hotel.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* country
+
+Hotel.country() `view` `d8b0b499`
+
+
+
+
+
+## *function* callUnitType
+
+Hotel.callUnitType(unitType, data) `nonpayable` `dbc6c290`
+
+> `callUnitType` allows the owner to call a unit type
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | unitType | The type of unit |
+| *bytes* | data | The data of the call to execute on the `UnitType` contract |
+
+
+## *function* addUnitType
+
+Hotel.addUnitType(addr) `nonpayable` `dc8f86e5`
+
+> `addUnitType` allows the owner to add a new unit type
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | The address of the `UnitType` contract |
+
+
+## *function* units
+
+Hotel.units() `view` `e5fba6cc`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* deleteUnit
+
+Hotel.deleteUnit(unit) `nonpayable` `e6c94c94`
+
+> `deleteUnit` allows the owner to remove a unit from the inventory
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unit | The address of the `Unit` contract |
+
+
+## *function* deleteUnitType
+
+Hotel.deleteUnitType(unitType, index) `nonpayable` `e8782acf`
+
+> `deleteUnitType` allows the owner to delete a unit type
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | unitType | The type of unit |
+| *uint256* | index | The unit's index in the `unitTypeNames` array |
+
+
+## *function* lineTwo
+
+Hotel.lineTwo() `view` `ed7fa4f1`
+
+
+
+
+
+## *function* transferOwnership
+
+Hotel.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+
+## *function* destroyAndSend
+
+Hotel.destroyAndSend(_recipient) `nonpayable` `f5074f41`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _recipient | undefined |
+
+
+## *event* Book
+
+Hotel.Book(from, unit, fromDay, daysAmount) `a7fd659d`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *address* | unit | not indexed |
+| *uint256* | fromDay | not indexed |
+| *uint256* | daysAmount | not indexed |
+
+## *event* CallStarted
+
+Hotel.CallStarted(from, dataHash) `5ec33322`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *bytes32* | dataHash | not indexed |
+
+## *event* CallFinish
+
+Hotel.CallFinish(from, dataHash) `b2be3874`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *bytes32* | dataHash | not indexed |
+
+## *event* OwnershipTransferred
+
+Hotel.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/Hotel_Interface.md
+++ b/docs/Hotel_Interface.md
@@ -1,0 +1,578 @@
+* [Hotel_Interface](#hotel_interface)
+  * [zip](#function-zip)
+  * [name](#function-name)
+  * [editInfo](#function-editinfo)
+  * [addImage](#function-addimage)
+  * [callUnit](#function-callunit)
+  * [beginCall](#function-begincall)
+  * [getLifCost](#function-getlifcost)
+  * [unitTypeNames](#function-unittypenames)
+  * [lineOne](#function-lineone)
+  * [unitTypes](#function-unittypes)
+  * [getUnitTypeNames](#function-getunittypenames)
+  * [created](#function-created)
+  * [pendingCalls](#function-pendingcalls)
+  * [changeUnitType](#function-changeunittype)
+  * [continueCall](#function-continuecall)
+  * [changeConfirmation](#function-changeconfirmation)
+  * [manager](#function-manager)
+  * [latitude](#function-latitude)
+  * [version](#function-version)
+  * [longitude](#function-longitude)
+  * [unitsIndex](#function-unitsindex)
+  * [editAddress](#function-editaddress)
+  * [getImagesLength](#function-getimageslength)
+  * [getCost](#function-getcost)
+  * [bookWithLif](#function-bookwithlif)
+  * [description](#function-description)
+  * [getUnitType](#function-getunittype)
+  * [images](#function-images)
+  * [removeImage](#function-removeimage)
+  * [owner](#function-owner)
+  * [addUnit](#function-addunit)
+  * [waitConfirmation](#function-waitconfirmation)
+  * [book](#function-book)
+  * [timezone](#function-timezone)
+  * [contractType](#function-contracttype)
+  * [removeUnitType](#function-removeunittype)
+  * [country](#function-country)
+  * [callUnitType](#function-callunittype)
+  * [addUnitType](#function-addunittype)
+  * [removeUnit](#function-removeunit)
+  * [units](#function-units)
+  * [lineTwo](#function-linetwo)
+  * [transferOwnership](#function-transferownership)
+  * [Book](#event-book)
+  * [CallStarted](#event-callstarted)
+  * [CallFinish](#event-callfinish)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# Hotel_Interface
+
+
+## *function* zip
+
+Hotel_Interface.zip() `view` `00919055`
+
+
+
+
+
+## *function* name
+
+Hotel_Interface.name() `view` `06fdde03`
+
+
+
+
+
+## *function* editInfo
+
+Hotel_Interface.editInfo(_name, _description) `nonpayable` `0b0d3ca2`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _name | undefined |
+| *string* | _description | undefined |
+
+
+## *function* addImage
+
+Hotel_Interface.addImage(url) `nonpayable` `166f1779`
+
+> `addImage` allows the owner to add an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | url | The url of the image |
+
+
+## *function* callUnit
+
+Hotel_Interface.callUnit(unitAddress, data) `nonpayable` `1c4e4d46`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | undefined |
+| *bytes* | data | undefined |
+
+
+## *function* beginCall
+
+Hotel_Interface.beginCall(publicCallData, privateData) `nonpayable` `203eaf27`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes* | publicCallData | undefined |
+| *bytes* | privateData | undefined |
+
+
+## *function* getLifCost
+
+Hotel_Interface.getLifCost(unitAddress, fromDay, daysAmount) `view` `25820f61`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | undefined |
+| *uint256* | fromDay | undefined |
+| *uint256* | daysAmount | undefined |
+
+
+## *function* unitTypeNames
+
+Hotel_Interface.unitTypeNames() `view` `28ef6b93`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* lineOne
+
+Hotel_Interface.lineOne() `view` `2a323572`
+
+
+
+
+
+## *function* unitTypes
+
+Hotel_Interface.unitTypes() `view` `2bb03f6e`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
+
+
+## *function* getUnitTypeNames
+
+Hotel_Interface.getUnitTypeNames() `view` `2db25a38`
+
+
+
+
+
+## *function* created
+
+Hotel_Interface.created() `view` `325a19f1`
+
+
+
+
+
+## *function* pendingCalls
+
+Hotel_Interface.pendingCalls() `view` `32fdd45c`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
+
+
+## *function* changeUnitType
+
+Hotel_Interface.changeUnitType(unitType, newAddr) `nonpayable` `37844767`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | unitType | undefined |
+| *address* | newAddr | undefined |
+
+
+## *function* continueCall
+
+Hotel_Interface.continueCall(msgDataHash) `nonpayable` `411f2351`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | msgDataHash | undefined |
+
+
+## *function* changeConfirmation
+
+Hotel_Interface.changeConfirmation(_waitConfirmation) `nonpayable` `44f5484a`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* | _waitConfirmation | undefined |
+
+
+## *function* manager
+
+Hotel_Interface.manager() `view` `481c6a75`
+
+
+
+
+
+## *function* latitude
+
+Hotel_Interface.latitude() `view` `4fd7d76a`
+
+
+
+
+
+## *function* version
+
+Hotel_Interface.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* longitude
+
+Hotel_Interface.longitude() `view` `589af69c`
+
+
+
+
+
+## *function* unitsIndex
+
+Hotel_Interface.unitsIndex() `view` `5edad458`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
+
+
+## *function* editAddress
+
+Hotel_Interface.editAddress(_lineOne, _lineTwo, _zip, _country, _timezone, _longitude, _latitude) `nonpayable` `5efa8a7c`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _lineOne | undefined |
+| *string* | _lineTwo | undefined |
+| *string* | _zip | undefined |
+| *bytes2* | _country | undefined |
+| *string* | _timezone | undefined |
+| *uint256* | _longitude | undefined |
+| *uint256* | _latitude | undefined |
+
+
+## *function* getImagesLength
+
+Hotel_Interface.getImagesLength() `view` `60839bd8`
+
+> `getImagesLength` get the length of the `images` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _length | Length of the `images` array |
+
+## *function* getCost
+
+Hotel_Interface.getCost(unitAddress, fromDay, daysAmount) `view` `62a966b0`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | undefined |
+| *uint256* | fromDay | undefined |
+| *uint256* | daysAmount | undefined |
+
+
+## *function* bookWithLif
+
+Hotel_Interface.bookWithLif(unitAddress, from, fromDay, daysAmount) `nonpayable` `676e0079`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | undefined |
+| *address* | from | undefined |
+| *uint256* | fromDay | undefined |
+| *uint256* | daysAmount | undefined |
+
+
+## *function* description
+
+Hotel_Interface.description() `view` `7284e416`
+
+
+
+
+
+## *function* getUnitType
+
+Hotel_Interface.getUnitType(unitType) `view` `7e1d63c3`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | unitType | undefined |
+
+
+## *function* images
+
+Hotel_Interface.images() `view` `84856482`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* removeImage
+
+Hotel_Interface.removeImage(index) `nonpayable` `8b25261f`
+
+> `removeImage` allows the owner to remove an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | index | The image's index in the `images` array |
+
+
+## *function* owner
+
+Hotel_Interface.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* addUnit
+
+Hotel_Interface.addUnit(unit) `nonpayable` `a9f7f247`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unit | undefined |
+
+
+## *function* waitConfirmation
+
+Hotel_Interface.waitConfirmation() `view` `ac72bb98`
+
+
+
+
+
+## *function* book
+
+Hotel_Interface.book(unitAddress, from, fromDay, daysAmount) `nonpayable` `b9a527b4`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unitAddress | undefined |
+| *address* | from | undefined |
+| *uint256* | fromDay | undefined |
+| *uint256* | daysAmount | undefined |
+
+
+## *function* timezone
+
+Hotel_Interface.timezone() `view` `c4148fe5`
+
+
+
+
+
+## *function* contractType
+
+Hotel_Interface.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* removeUnitType
+
+Hotel_Interface.removeUnitType(unitType, index) `nonpayable` `d5268e8c`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | unitType | undefined |
+| *uint256* | index | undefined |
+
+
+## *function* country
+
+Hotel_Interface.country() `view` `d8b0b499`
+
+
+
+
+
+## *function* callUnitType
+
+Hotel_Interface.callUnitType(unitType, data) `nonpayable` `dbc6c290`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | unitType | undefined |
+| *bytes* | data | undefined |
+
+
+## *function* addUnitType
+
+Hotel_Interface.addUnitType(addr) `nonpayable` `dc8f86e5`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | undefined |
+
+
+## *function* removeUnit
+
+Hotel_Interface.removeUnit(unit) `nonpayable` `df155165`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | unit | undefined |
+
+
+## *function* units
+
+Hotel_Interface.units() `view` `e5fba6cc`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* lineTwo
+
+Hotel_Interface.lineTwo() `view` `ed7fa4f1`
+
+
+
+
+
+## *function* transferOwnership
+
+Hotel_Interface.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+## *event* Book
+
+Hotel_Interface.Book(from, unit, fromDay, daysAmount) `a7fd659d`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *address* | unit | not indexed |
+| *uint256* | fromDay | not indexed |
+| *uint256* | daysAmount | not indexed |
+
+## *event* CallStarted
+
+Hotel_Interface.CallStarted(from, dataHash) `5ec33322`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *bytes32* | dataHash | not indexed |
+
+## *event* CallFinish
+
+Hotel_Interface.CallFinish(from, dataHash) `b2be3874`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *bytes32* | dataHash | not indexed |
+
+## *event* OwnershipTransferred
+
+Hotel_Interface.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/Images.md
+++ b/docs/Images.md
@@ -1,0 +1,115 @@
+* [Images](#images)
+  * [addImage](#function-addimage)
+  * [version](#function-version)
+  * [getImagesLength](#function-getimageslength)
+  * [images](#function-images)
+  * [removeImage](#function-removeimage)
+  * [owner](#function-owner)
+  * [contractType](#function-contracttype)
+  * [transferOwnership](#function-transferownership)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# Images
+
+
+## *function* addImage
+
+Images.addImage(url) `nonpayable` `166f1779`
+
+> `addImage` allows the owner to add an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | url | The url of the image |
+
+
+## *function* version
+
+Images.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* getImagesLength
+
+Images.getImagesLength() `view` `60839bd8`
+
+> `getImagesLength` get the length of the `images` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _length | Length of the `images` array |
+
+## *function* images
+
+Images.images() `view` `84856482`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* removeImage
+
+Images.removeImage(index) `nonpayable` `8b25261f`
+
+> `removeImage` allows the owner to remove an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | index | The image's index in the `images` array |
+
+
+## *function* owner
+
+Images.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* contractType
+
+Images.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* transferOwnership
+
+Images.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+## *event* OwnershipTransferred
+
+Images.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/Index_Interface.md
+++ b/docs/Index_Interface.md
@@ -1,0 +1,15 @@
+* [Index_Interface](#index_interface)
+  * [LifToken](#function-liftoken)
+
+# Index_Interface
+
+
+## *function* LifToken
+
+Index_Interface.LifToken() `view` `554d8b37`
+
+
+
+
+
+---

--- a/docs/Unit.md
+++ b/docs/Unit.md
@@ -1,0 +1,189 @@
+* [Unit](#unit)
+  * [active](#function-active)
+  * [setSpecialPrice](#function-setspecialprice)
+  * [version](#function-version)
+  * [destroy](#function-destroy)
+  * [unitType](#function-unittype)
+  * [owner](#function-owner)
+  * [setActive](#function-setactive)
+  * [book](#function-book)
+  * [contractType](#function-contracttype)
+  * [getReservation](#function-getreservation)
+  * [transferOwnership](#function-transferownership)
+  * [destroyAndSend](#function-destroyandsend)
+  * [setSpecialLifPrice](#function-setspeciallifprice)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# Unit
+
+
+## *function* active
+
+Unit.active() `view` `02fb0c5e`
+
+
+
+
+
+## *function* setSpecialPrice
+
+Unit.setSpecialPrice(price, fromDay, daysAmount) `nonpayable` `46a8e678`
+
+> `setPrice` allows the owner of the contract to set a speical price in the custom currency for a range of dates
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | price | The price of the unit |
+| *uint256* | fromDay | The starting date of the period of days to change |
+| *uint256* | daysAmount | The amount of days in the period |
+
+
+## *function* version
+
+Unit.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* destroy
+
+Unit.destroy() `nonpayable` `83197ef0`
+
+> Transfers the current balance to the owner and terminates the contract.
+
+
+
+
+## *function* unitType
+
+Unit.unitType() `view` `85ad4f90`
+
+
+
+
+
+## *function* owner
+
+Unit.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* setActive
+
+Unit.setActive(_active) `nonpayable` `acec338a`
+
+> `setActive` allows the owner of the contract to switch the status
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* | _active | The new status of the unit |
+
+
+## *function* book
+
+Unit.book(from, fromDay, daysAmount) `nonpayable` `c78e687c`
+
+> `book` allows the owner to make a reservation
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | The address of the opener of the reservation |
+| *uint256* | fromDay | The starting day of the period of days to book |
+| *uint256* | daysAmount | The amount of days in the booking period |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* | _bookingResult | Whether the booking was successful or not |
+
+## *function* contractType
+
+Unit.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* getReservation
+
+Unit.getReservation(day) `view` `d57763c3`
+
+> `getReservation` get the avalibility and price of a day
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | day | The number of days after 01-01-1970 |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _specialPrice | The price of the day in the custom currency, 0 if default price |
+| *uint256* | _specialLifPrice | The price of the day in Líf, 0 if default price |
+| *address* | _bookedBy | The address of the owner of the reservation, returns 0x0 if its available |
+
+## *function* transferOwnership
+
+Unit.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+
+## *function* destroyAndSend
+
+Unit.destroyAndSend(_recipient) `nonpayable` `f5074f41`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _recipient | undefined |
+
+
+## *function* setSpecialLifPrice
+
+Unit.setSpecialLifPrice(price, fromDay, daysAmount) `nonpayable` `fd480e5f`
+
+> `setSpecialLifPrice` allows the owner of the contract to set a special price in Líf for a range of days
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | price | The price of the unit |
+| *uint256* | fromDay | The starting date of the period of days to change |
+| *uint256* | daysAmount | The amount of days in the period |
+
+
+## *event* OwnershipTransferred
+
+Unit.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/UnitType.md
+++ b/docs/UnitType.md
@@ -1,0 +1,323 @@
+* [UnitType](#unittype)
+  * [removeAmenity](#function-removeamenity)
+  * [addImage](#function-addimage)
+  * [setCurrencyCode](#function-setcurrencycode)
+  * [increaseUnits](#function-increaseunits)
+  * [defaultLifPrice](#function-defaultlifprice)
+  * [version](#function-version)
+  * [getInfo](#function-getinfo)
+  * [getImagesLength](#function-getimageslength)
+  * [setDefaultPrice](#function-setdefaultprice)
+  * [totalUnits](#function-totalunits)
+  * [decreaseUnits](#function-decreaseunits)
+  * [destroy](#function-destroy)
+  * [images](#function-images)
+  * [unitType](#function-unittype)
+  * [removeImage](#function-removeimage)
+  * [owner](#function-owner)
+  * [edit](#function-edit)
+  * [setDefaultLifPrice](#function-setdefaultlifprice)
+  * [contractType](#function-contracttype)
+  * [getAmenities](#function-getamenities)
+  * [currencyCode](#function-currencycode)
+  * [defaultPrice](#function-defaultprice)
+  * [addAmenity](#function-addamenity)
+  * [transferOwnership](#function-transferownership)
+  * [destroyAndSend](#function-destroyandsend)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# UnitType
+
+
+## *function* removeAmenity
+
+UnitType.removeAmenity(amenityId) `nonpayable` `0ad23923`
+
+> `removeAmenity` allows the owner to remove an amenity
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | amenityId | The id of the amenity in the amenitiesIndex array |
+
+
+## *function* addImage
+
+UnitType.addImage(url) `nonpayable` `166f1779`
+
+> `addImage` allows the owner to add an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | url | The url of the image |
+
+
+## *function* setCurrencyCode
+
+UnitType.setCurrencyCode(_currencyCode) `nonpayable` `2914fc0a`
+
+> `setCurrencyCode` allows the owner of the contract to set which currency other than Líf the UnitType is priced in
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes8* | _currencyCode | The hex value of the currency code |
+
+
+## *function* increaseUnits
+
+UnitType.increaseUnits() `nonpayable` `362db291`
+
+> `increaseUnits` allows the owner to increase the `totalUnits`
+
+
+
+
+## *function* defaultLifPrice
+
+UnitType.defaultLifPrice() `view` `4e922d6d`
+
+
+
+
+
+## *function* version
+
+UnitType.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* getInfo
+
+UnitType.getInfo() `view` `5a9b0b89`
+
+> `GetInfo` get the information of the unit
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _description | The description of the unit type |
+| *uint256* | _minGuests | The minimun amount guests |
+| *uint256* | _maxGuests | The maximum amount guests |
+| *uint256* | _defaultPrice | The default fiat price |
+
+## *function* getImagesLength
+
+UnitType.getImagesLength() `view` `60839bd8`
+
+> `getImagesLength` get the length of the `images` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _length | Length of the `images` array |
+
+## *function* setDefaultPrice
+
+UnitType.setDefaultPrice(price) `nonpayable` `6d3c7ec5`
+
+> `setDefaultPrice` allows the owner of the contract to set the default price in the custom currency for reserving the UnitType for 1 day
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | price | The new default price |
+
+
+## *function* totalUnits
+
+UnitType.totalUnits() `view` `6d86acc4`
+
+
+
+
+
+## *function* decreaseUnits
+
+UnitType.decreaseUnits() `nonpayable` `72730c01`
+
+> `decreaseUnits` allows the owner to decrease the `totalUnits`
+
+
+
+
+## *function* destroy
+
+UnitType.destroy() `nonpayable` `83197ef0`
+
+> Transfers the current balance to the owner and terminates the contract.
+
+
+
+
+## *function* images
+
+UnitType.images() `view` `84856482`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* unitType
+
+UnitType.unitType() `view` `85ad4f90`
+
+
+
+
+
+## *function* removeImage
+
+UnitType.removeImage(index) `nonpayable` `8b25261f`
+
+> `removeImage` allows the owner to remove an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | index | The image's index in the `images` array |
+
+
+## *function* owner
+
+UnitType.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* edit
+
+UnitType.edit(_description, _minGuests, _maxGuests) `nonpayable` `ae9a6137`
+
+> `edit` allows the owner of the contract to change the description, min/max guests and base price
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _description | The new description |
+| *uint256* | _minGuests | The minimun amount of guests allowed |
+| *uint256* | _maxGuests | The maximum amount of guests allowed |
+
+
+## *function* setDefaultLifPrice
+
+UnitType.setDefaultLifPrice(price) `nonpayable` `c55b2ee7`
+
+> `setDefaultLifPrice` allows the owner of the contract to set the default price in Lif for reserving the UnitType for 1 day
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | price | The new default Lif price |
+
+
+## *function* contractType
+
+UnitType.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* getAmenities
+
+UnitType.getAmenities() `view` `d0ceaae8`
+
+> `getAmenities` get the amenities ids
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256[]* | _amenities | Array of all the amenities ids in the unit type |
+
+## *function* currencyCode
+
+UnitType.currencyCode() `view` `e102e5e3`
+
+
+
+
+
+## *function* defaultPrice
+
+UnitType.defaultPrice() `view` `e69e04b3`
+
+
+
+
+
+## *function* addAmenity
+
+UnitType.addAmenity(amenityId) `nonpayable` `f240180c`
+
+> `addAmenity` allows the owner to add an amenity.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | amenityId | The id of the amenity to add |
+
+
+## *function* transferOwnership
+
+UnitType.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+
+## *function* destroyAndSend
+
+UnitType.destroyAndSend(_recipient) `nonpayable` `f5074f41`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _recipient | undefined |
+
+
+## *event* OwnershipTransferred
+
+UnitType.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/UnitType_Interface.md
+++ b/docs/UnitType_Interface.md
@@ -1,0 +1,289 @@
+* [UnitType_Interface](#unittype_interface)
+  * [removeAmenity](#function-removeamenity)
+  * [addImage](#function-addimage)
+  * [setCurrencyCode](#function-setcurrencycode)
+  * [increaseUnits](#function-increaseunits)
+  * [defaultLifPrice](#function-defaultlifprice)
+  * [version](#function-version)
+  * [getInfo](#function-getinfo)
+  * [getImagesLength](#function-getimageslength)
+  * [setDefaultPrice](#function-setdefaultprice)
+  * [totalUnits](#function-totalunits)
+  * [decreaseUnits](#function-decreaseunits)
+  * [images](#function-images)
+  * [unitType](#function-unittype)
+  * [removeImage](#function-removeimage)
+  * [owner](#function-owner)
+  * [edit](#function-edit)
+  * [setDefaultLifPrice](#function-setdefaultlifprice)
+  * [contractType](#function-contracttype)
+  * [getAmenities](#function-getamenities)
+  * [currencyCode](#function-currencycode)
+  * [defaultPrice](#function-defaultprice)
+  * [addAmenity](#function-addamenity)
+  * [transferOwnership](#function-transferownership)
+  * [removeUnit](#function-removeunit)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# UnitType_Interface
+
+
+## *function* removeAmenity
+
+UnitType_Interface.removeAmenity(amenity) `nonpayable` `0ad23923`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | amenity | undefined |
+
+
+## *function* addImage
+
+UnitType_Interface.addImage(url) `nonpayable` `166f1779`
+
+> `addImage` allows the owner to add an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | url | The url of the image |
+
+
+## *function* setCurrencyCode
+
+UnitType_Interface.setCurrencyCode(_currencyCode) `nonpayable` `2914fc0a`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes8* | _currencyCode | undefined |
+
+
+## *function* increaseUnits
+
+UnitType_Interface.increaseUnits() `nonpayable` `362db291`
+
+
+
+
+
+## *function* defaultLifPrice
+
+UnitType_Interface.defaultLifPrice() `view` `4e922d6d`
+
+
+
+
+
+## *function* version
+
+UnitType_Interface.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* getInfo
+
+UnitType_Interface.getInfo() `view` `5a9b0b89`
+
+
+
+
+
+## *function* getImagesLength
+
+UnitType_Interface.getImagesLength() `view` `60839bd8`
+
+> `getImagesLength` get the length of the `images` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _length | Length of the `images` array |
+
+## *function* setDefaultPrice
+
+UnitType_Interface.setDefaultPrice(price) `nonpayable` `6d3c7ec5`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | price | undefined |
+
+
+## *function* totalUnits
+
+UnitType_Interface.totalUnits() `view` `6d86acc4`
+
+
+
+
+
+## *function* decreaseUnits
+
+UnitType_Interface.decreaseUnits() `nonpayable` `72730c01`
+
+
+
+
+
+## *function* images
+
+UnitType_Interface.images() `view` `84856482`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* unitType
+
+UnitType_Interface.unitType() `view` `85ad4f90`
+
+
+
+
+
+## *function* removeImage
+
+UnitType_Interface.removeImage(index) `nonpayable` `8b25261f`
+
+> `removeImage` allows the owner to remove an image
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | index | The image's index in the `images` array |
+
+
+## *function* owner
+
+UnitType_Interface.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* edit
+
+UnitType_Interface.edit(description, minGuests, maxGuests) `nonpayable` `ae9a6137`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | description | undefined |
+| *uint256* | minGuests | undefined |
+| *uint256* | maxGuests | undefined |
+
+
+## *function* setDefaultLifPrice
+
+UnitType_Interface.setDefaultLifPrice(price) `nonpayable` `c55b2ee7`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | price | undefined |
+
+
+## *function* contractType
+
+UnitType_Interface.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* getAmenities
+
+UnitType_Interface.getAmenities() `view` `d0ceaae8`
+
+
+
+
+
+## *function* currencyCode
+
+UnitType_Interface.currencyCode() `view` `e102e5e3`
+
+
+
+
+
+## *function* defaultPrice
+
+UnitType_Interface.defaultPrice() `view` `e69e04b3`
+
+
+
+
+
+## *function* addAmenity
+
+UnitType_Interface.addAmenity(amenity) `nonpayable` `f240180c`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | amenity | undefined |
+
+
+## *function* transferOwnership
+
+UnitType_Interface.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+
+## *function* removeUnit
+
+UnitType_Interface.removeUnit(unitIndex) `nonpayable` `ff3c6039`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | unitIndex | undefined |
+
+## *event* OwnershipTransferred
+
+UnitType_Interface.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/Unit_Interface.md
+++ b/docs/Unit_Interface.md
@@ -1,0 +1,152 @@
+* [Unit_Interface](#unit_interface)
+  * [active](#function-active)
+  * [setSpecialPrice](#function-setspecialprice)
+  * [defaultLifTokenPrice](#function-defaultliftokenprice)
+  * [unitType](#function-unittype)
+  * [owner](#function-owner)
+  * [setActive](#function-setactive)
+  * [book](#function-book)
+  * [getReservation](#function-getreservation)
+  * [transferOwnership](#function-transferownership)
+  * [setSpecialLifPrice](#function-setspeciallifprice)
+  * [Book](#event-book)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# Unit_Interface
+
+
+## *function* active
+
+Unit_Interface.active() `view` `02fb0c5e`
+
+
+
+
+
+## *function* setSpecialPrice
+
+Unit_Interface.setSpecialPrice(price, fromDay, daysAmount) `nonpayable` `46a8e678`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | price | undefined |
+| *uint256* | fromDay | undefined |
+| *uint256* | daysAmount | undefined |
+
+
+## *function* defaultLifTokenPrice
+
+Unit_Interface.defaultLifTokenPrice() `view` `7d40192d`
+
+
+
+
+
+## *function* unitType
+
+Unit_Interface.unitType() `view` `85ad4f90`
+
+
+
+
+
+## *function* owner
+
+Unit_Interface.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* setActive
+
+Unit_Interface.setActive(_active) `nonpayable` `acec338a`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* | _active | undefined |
+
+
+## *function* book
+
+Unit_Interface.book(from, fromDay, daysAmount) `nonpayable` `c78e687c`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | undefined |
+| *uint256* | fromDay | undefined |
+| *uint256* | daysAmount | undefined |
+
+
+## *function* getReservation
+
+Unit_Interface.getReservation(day) `view` `d57763c3`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | day | undefined |
+
+
+## *function* transferOwnership
+
+Unit_Interface.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+
+## *function* setSpecialLifPrice
+
+Unit_Interface.setSpecialLifPrice(price, fromDay, daysAmount) `nonpayable` `fd480e5f`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | price | undefined |
+| *uint256* | fromDay | undefined |
+| *uint256* | daysAmount | undefined |
+
+## *event* Book
+
+Unit_Interface.Book(from, fromDay, daysAmount) `923908e9`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | from | not indexed |
+| *uint256* | fromDay | not indexed |
+| *uint256* | daysAmount | not indexed |
+
+## *event* OwnershipTransferred
+
+Unit_Interface.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/WTContracts.md
+++ b/docs/WTContracts.md
@@ -1,0 +1,156 @@
+* [WTContracts](#wtcontracts)
+  * [register](#function-register)
+  * [getByAddr](#function-getbyaddr)
+  * [total](#function-total)
+  * [version](#function-version)
+  * [getContract](#function-getcontract)
+  * [owner](#function-owner)
+  * [getByName](#function-getbyname)
+  * [edit](#function-edit)
+  * [contractType](#function-contracttype)
+  * [transferOwnership](#function-transferownership)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# WTContracts
+
+
+## *function* register
+
+WTContracts.register(_name, _addr, _version) `nonpayable` `0578dd1c`
+
+> `register` allows the owner to register a new contract
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _name | The name of the contract to be registered |
+| *address* | _addr | The contract's address |
+| *string* | _version | The contract's version |
+
+
+## *function* getByAddr
+
+WTContracts.getByAddr(_addr) `view` `259a1a34`
+
+> `getByAddr` get the info of a registered contract by address
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _addr | The registered contract's address |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _name | Contract name or empty string |
+| *address* | _address | Contract address or zero address |
+| *string* | _version | Contract version or empty string |
+
+## *function* total
+
+WTContracts.total() `view` `2ddbd13a`
+
+
+
+
+
+## *function* version
+
+WTContracts.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* getContract
+
+WTContracts.getContract(_pos) `view` `6ebc8c86`
+
+> `getContract` get the info of a registered contract by index
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _pos | The registered contract's index returns {name, address, url, version} The contract's information |
+
+
+## *function* owner
+
+WTContracts.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* getByName
+
+WTContracts.getByName(_name) `view` `b336ad83`
+
+> `getByName` get the info of a registered contract by name
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _name | The registered contract's name |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _contractName | Contract name or empty string |
+| *address* | _address | Contract address or zero address |
+| *string* | _version | Contract version or empty string |
+
+## *function* edit
+
+WTContracts.edit(_name, _addr, _version) `nonpayable` `c362e82d`
+
+> `edit` allows an owner to edit a registered contract
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _name | The name of the contract to edit |
+| *address* | _addr | The contract's new address |
+| *string* | _version | The contract's new version |
+
+
+## *function* contractType
+
+WTContracts.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* transferOwnership
+
+WTContracts.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+## *event* OwnershipTransferred
+
+WTContracts.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/docs/WTIndex.md
+++ b/docs/WTIndex.md
@@ -1,0 +1,246 @@
+* [WTIndex](#wtindex)
+  * [getHotels](#function-gethotels)
+  * [version](#function-version)
+  * [LifToken](#function-liftoken)
+  * [hotelsByManager](#function-hotelsbymanager)
+  * [deleteHotel](#function-deletehotel)
+  * [owner](#function-owner)
+  * [DAO](#function-dao)
+  * [hotelsIndex](#function-hotelsindex)
+  * [getHotelsByManager](#function-gethotelsbymanager)
+  * [getHotelsLength](#function-gethotelslength)
+  * [contractType](#function-contracttype)
+  * [hotels](#function-hotels)
+  * [registerHotel](#function-registerhotel)
+  * [callHotel](#function-callhotel)
+  * [setDAO](#function-setdao)
+  * [setLifToken](#function-setliftoken)
+  * [transferOwnership](#function-transferownership)
+  * [log](#event-log)
+  * [OwnershipTransferred](#event-ownershiptransferred)
+
+# WTIndex
+
+
+## *function* getHotels
+
+WTIndex.getHotels() `view` `0d2e677a`
+
+> `getHotels` get `hotels` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address[]* | _hotels | The addresses of all `Hotel` contracts |
+
+## *function* version
+
+WTIndex.version() `view` `54fd4d50`
+
+
+
+
+
+## *function* LifToken
+
+WTIndex.LifToken() `view` `554d8b37`
+
+
+
+
+
+## *function* hotelsByManager
+
+WTIndex.hotelsByManager(, ) `view` `7cf2dfae`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
+| *uint256* |  | undefined |
+
+
+## *function* deleteHotel
+
+WTIndex.deleteHotel(index) `nonpayable` `80254127`
+
+> `deleteHotel` Allows a manager to delete a hotel, along with its Units and UnitTypes
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | index | The hotel's index |
+
+
+## *function* owner
+
+WTIndex.owner() `view` `8da5cb5b`
+
+
+
+
+
+## *function* DAO
+
+WTIndex.DAO() `view` `98fabd3a`
+
+
+
+
+
+## *function* hotelsIndex
+
+WTIndex.hotelsIndex() `view` `9f9bfeb8`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
+
+
+## *function* getHotelsByManager
+
+WTIndex.getHotelsByManager(owner) `view` `bb979c3d`
+
+> `getHotelsByManager` get all the hotels belonging to one manager
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | owner | undefined |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address[]* | _hotels | The addresses of `Hotel` contracts that belong to one manager |
+
+## *function* getHotelsLength
+
+WTIndex.getHotelsLength() `view` `ca63a55b`
+
+> `getHotelsLength` get the length of the `hotels` array
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | _length | Length of the `hotels` array |
+
+## *function* contractType
+
+WTIndex.contractType() `view` `cb2ef6f7`
+
+
+
+
+
+## *function* hotels
+
+WTIndex.hotels() `view` `cd338265`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* registerHotel
+
+WTIndex.registerHotel(name, description) `nonpayable` `dc52ab73`
+
+> `registerHotel` Register new hotel in the index
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | name | The name of the hotel |
+| *string* | description | The description of the hotel |
+
+
+## *function* callHotel
+
+WTIndex.callHotel(index, data) `nonpayable` `deb749a9`
+
+> `callHotel` Call hotel in the index, the hotel can only be called by its manager
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* | index | The index position of the hotel |
+| *bytes* | data | The data to be executed in the hotel contract |
+
+
+## *function* setDAO
+
+WTIndex.setDAO(_DAO) `nonpayable` `e73a914c`
+
+> `setDAO` allows the owner of the contract to change the address of the DAO contract
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _DAO | The new contract address |
+
+
+## *function* setLifToken
+
+WTIndex.setLifToken(_LifToken) `nonpayable` `f2f0967b`
+
+> `setLifToken` allows the owner of the contract to change the address of the LifToken contract
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _LifToken | The new contract address |
+
+
+## *function* transferOwnership
+
+WTIndex.transferOwnership(newOwner) `nonpayable` `f2fde38b`
+
+> Allows the current owner to transfer control of the contract to a newOwner.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | newOwner | The address to transfer ownership to. |
+
+
+## *event* log
+
+WTIndex.log() `51973ec9`
+
+
+
+## *event* OwnershipTransferred
+
+WTIndex.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | previousOwner | indexed |
+| *address* | newOwner | indexed |
+
+
+---

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "resolved": "https://registry.npmjs.org/@windingtree/lif-token/-/lif-token-0.1.2-erc827.tgz",
       "integrity": "sha512-JcAN3XPYwo0HAm8oR1nDL41qDIJxEDZS+5MvFTxUzwsfBK/fgYoV7zs8jBKBsmGAr694vv6oYgpFXv6ZBOxHGg==",
       "requires": {
-        "abi-decoder": "1.0.9",
-        "ethereumjs-abi": "0.6.5",
-        "jsverify": "0.8.3",
-        "lodash": "4.17.5",
-        "rimraf": "2.6.2",
+        "abi-decoder": "^1.0.8",
+        "ethereumjs-abi": "^0.6.4",
+        "jsverify": "^0.8.2",
+        "lodash": "^4.17.4",
+        "rimraf": "^2.6.2",
         "truffle-hdwallet-provider": "0.0.3",
-        "zeppelin-solidity": "1.6.0"
+        "zeppelin-solidity": "^1.6.0"
       }
     },
     "abbrev": {
@@ -29,14 +29,14 @@
       "resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.0.9.tgz",
       "integrity": "sha1-a8/Yb39j++yFc9l3izpPkruS4B8=",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-loader": "6.4.1",
-        "babel-plugin-add-module-exports": "0.2.1",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-preset-es2015": "6.24.1",
-        "chai": "3.5.0",
-        "web3": "0.18.4",
-        "webpack": "2.7.0"
+        "babel-core": "^6.23.1",
+        "babel-loader": "^6.3.2",
+        "babel-plugin-add-module-exports": "^0.2.1",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-preset-es2015": "^6.22.0",
+        "chai": "^3.5.0",
+        "web3": "^0.18.4",
+        "webpack": "^2.2.1"
       },
       "dependencies": {
         "web3": {
@@ -58,7 +58,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
       "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "~4.0.0"
       }
     },
     "accepts": {
@@ -66,7 +66,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -80,7 +80,7 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -100,8 +100,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ajv-keywords": {
@@ -114,9 +114,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -145,8 +145,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "argparse": {
@@ -155,7 +155,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -163,7 +163,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -191,9 +191,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -219,7 +219,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.14.0"
       }
     },
     "async-each": {
@@ -232,7 +232,7 @@
       "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
       "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "requires": {
-        "async": "2.6.0"
+        "async": "^2.4.0"
       }
     },
     "async-limiter": {
@@ -260,9 +260,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -270,25 +270,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       }
     },
     "babel-generator": {
@@ -296,14 +296,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -311,10 +311,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -322,10 +322,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-function-name": {
@@ -333,11 +333,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -345,8 +345,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -354,8 +354,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -363,8 +363,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -372,9 +372,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-replace-supers": {
@@ -382,12 +382,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -395,8 +395,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-loader": {
@@ -404,10 +404,10 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
       "requires": {
-        "find-cache-dir": "0.1.1",
-        "loader-utils": "0.2.17",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
+        "find-cache-dir": "^0.1.1",
+        "loader-utils": "^0.2.16",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.0.1"
       }
     },
     "babel-messages": {
@@ -415,7 +415,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-add-module-exports": {
@@ -428,7 +428,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -436,7 +436,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -444,7 +444,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -452,11 +452,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -464,15 +464,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -480,8 +480,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -489,7 +489,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -497,8 +497,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -506,7 +506,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -514,9 +514,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -524,7 +524,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -532,9 +532,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -542,10 +542,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -553,9 +553,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -563,9 +563,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -573,8 +573,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -582,12 +582,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -595,8 +595,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -604,7 +604,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -612,9 +612,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -622,7 +622,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -630,7 +630,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -638,9 +638,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -648,7 +648,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -656,8 +656,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -665,9 +665,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -682,30 +682,30 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-register": {
@@ -713,13 +713,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -727,8 +727,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -736,11 +736,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -748,15 +748,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.5"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -764,10 +764,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -796,7 +796,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "big.js": {
@@ -805,7 +805,8 @@
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "bignumber.js": {
-      "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+      "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+      "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -822,11 +823,11 @@
       "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
       "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
       "requires": {
-        "create-hash": "1.1.3",
-        "pbkdf2": "3.0.14",
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1",
-        "unorm": "1.4.1"
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "unorm": "^1.3.3"
       }
     },
     "bip66": {
@@ -834,7 +835,7 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "bl": {
@@ -842,7 +843,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.4"
+        "readable-stream": "^2.0.5"
       }
     },
     "block-stream": {
@@ -850,7 +851,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -869,15 +870,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       }
     },
     "boom": {
@@ -885,7 +886,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -893,7 +894,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -902,9 +903,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -923,12 +924,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -936,9 +937,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -946,9 +947,9 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -956,8 +957,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sha3": {
@@ -965,7 +966,7 @@
       "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
       "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
       "requires": {
-        "js-sha3": "0.3.1"
+        "js-sha3": "^0.3.1"
       }
     },
     "browserify-sign": {
@@ -973,13 +974,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -987,7 +988,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "bs58": {
@@ -995,7 +996,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
       "integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
       "requires": {
-        "base-x": "1.1.0"
+        "base-x": "^1.1.0"
       }
     },
     "bs58check": {
@@ -1003,8 +1004,8 @@
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-1.3.4.tgz",
       "integrity": "sha1-xSVABzdJEXcU+gQsMEfrj5FRy/g=",
       "requires": {
-        "bs58": "3.1.0",
-        "create-hash": "1.1.3"
+        "bs58": "^3.1.0",
+        "create-hash": "^1.1.0"
       }
     },
     "buffer": {
@@ -1012,9 +1013,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.2.3",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-crc32": {
@@ -1062,8 +1063,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -1071,9 +1072,9 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "requires": {
-        "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
       }
     },
     "chalk": {
@@ -1081,11 +1082,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "checkpoint-store": {
@@ -1093,7 +1094,7 @@
       "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
       "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
       "requires": {
-        "functional-red-black-tree": "1.0.1"
+        "functional-red-black-tree": "^1.0.1"
       }
     },
     "chokidar": {
@@ -1101,15 +1102,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "cipher-base": {
@@ -1117,8 +1118,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cliui": {
@@ -1126,8 +1127,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -1151,8 +1152,8 @@
       "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
       "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
       "requires": {
-        "bs58": "2.0.1",
-        "create-hash": "1.1.3"
+        "bs58": "^2.0.1",
+        "create-hash": "^1.1.1"
       },
       "dependencies": {
         "bs58": {
@@ -1167,7 +1168,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1175,7 +1176,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "commondir": {
@@ -1193,7 +1194,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -1241,8 +1242,8 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
       "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
       "requires": {
-        "object-assign": "4.1.1",
-        "vary": "1.1.2"
+        "object-assign": "^4",
+        "vary": "^1"
       }
     },
     "coveralls": {
@@ -1276,7 +1277,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -1297,7 +1298,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "form-data": {
@@ -1306,9 +1307,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
@@ -1317,10 +1318,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.14.1",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "hawk": {
@@ -1329,10 +1330,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -1347,9 +1348,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "minimist": {
@@ -1370,26 +1371,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "sntp": {
@@ -1398,7 +1399,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "tunnel-agent": {
@@ -1420,8 +1421,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -1429,10 +1430,10 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -1440,12 +1441,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -1454,9 +1455,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -1464,7 +1465,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1472,7 +1473,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -1482,17 +1483,17 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "crypto-js": {
@@ -1506,7 +1507,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -1514,7 +1515,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -1551,14 +1552,14 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "requires": {
-        "decompress-tar": "4.1.1",
-        "decompress-tarbz2": "4.1.1",
-        "decompress-targz": "4.1.1",
-        "decompress-unzip": "4.0.1",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
-        "pify": "2.3.0",
-        "strip-dirs": "2.1.0"
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
       }
     },
     "decompress-response": {
@@ -1566,7 +1567,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "decompress-tar": {
@@ -1574,9 +1575,9 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "requires": {
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0",
-        "tar-stream": "1.5.5"
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
       }
     },
     "decompress-tarbz2": {
@@ -1584,11 +1585,11 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "6.2.0",
-        "is-stream": "1.1.0",
-        "seek-bzip": "1.0.5",
-        "unbzip2-stream": "1.2.5"
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
@@ -1603,9 +1604,9 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0"
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
       }
     },
     "decompress-unzip": {
@@ -1613,10 +1614,10 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "requires": {
-        "file-type": "3.9.0",
-        "get-stream": "2.3.1",
-        "pify": "2.3.0",
-        "yauzl": "2.9.1"
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
@@ -1629,8 +1630,8 @@
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -1666,7 +1667,7 @@
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "requires": {
-        "abstract-leveldown": "2.6.3"
+        "abstract-leveldown": "~2.6.0"
       }
     },
     "define-properties": {
@@ -1674,8 +1675,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       },
       "dependencies": {
         "object-keys": {
@@ -1705,8 +1706,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -1719,7 +1720,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "diff": {
@@ -1733,9 +1734,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dom-walk": {
@@ -1748,6 +1749,12 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
+    "dot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.2.tgz",
+      "integrity": "sha1-xzdwGfxOVQeYkosrmv62ar+h8vk=",
+      "dev": true
+    },
     "dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
@@ -1758,9 +1765,9 @@
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "requires": {
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6"
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
       }
     },
     "duplexer3": {
@@ -1774,7 +1781,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -1787,13 +1794,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emojis-list": {
@@ -1811,7 +1818,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -1819,7 +1826,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -1827,10 +1834,10 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
       }
     },
     "errno": {
@@ -1838,7 +1845,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -1846,7 +1853,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -1854,11 +1861,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1866,9 +1873,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -1877,8 +1884,8 @@
       "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -1887,9 +1894,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -1898,12 +1905,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -1912,11 +1919,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -1925,8 +1932,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -1935,10 +1942,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -1957,11 +1964,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1977,7 +1984,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1988,10 +1995,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "esprima": {
@@ -2006,8 +2013,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -2031,13 +2038,13 @@
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
       "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0",
-        "keccakjs": "0.2.1",
-        "nano-json-stream-parser": "0.1.2",
-        "servify": "0.1.12",
-        "ws": "3.3.3",
-        "xhr-request-promise": "0.1.2"
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "keccakjs": "^0.2.1",
+        "nano-json-stream-parser": "^0.1.2",
+        "servify": "^0.1.12",
+        "ws": "^3.0.0",
+        "xhr-request-promise": "^0.1.2"
       }
     },
     "ethereum-common": {
@@ -2050,8 +2057,8 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
       "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
       "requires": {
-        "bn.js": "4.11.8",
-        "ethereumjs-util": "4.5.0"
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^4.3.0"
       }
     },
     "ethereumjs-account": {
@@ -2059,8 +2066,8 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",
       "integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
       "requires": {
-        "ethereumjs-util": "4.5.0",
-        "rlp": "2.0.0"
+        "ethereumjs-util": "^4.0.1",
+        "rlp": "^2.0.0"
       }
     },
     "ethereumjs-block": {
@@ -2068,11 +2075,11 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "requires": {
-        "async": "2.6.0",
+        "async": "^2.0.1",
         "ethereum-common": "0.2.0",
-        "ethereumjs-tx": "1.3.3",
-        "ethereumjs-util": "5.1.4",
-        "merkle-patricia-tree": "2.3.0"
+        "ethereumjs-tx": "^1.2.2",
+        "ethereumjs-util": "^5.0.0",
+        "merkle-patricia-tree": "^2.1.2"
       },
       "dependencies": {
         "ethereumjs-util": {
@@ -2080,13 +2087,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.4.tgz",
           "integrity": "sha512-wbeTc5prEzIWFSQUcEsCAZbqubtJKy6yS+oZMY1cGG6GLYzLjm4YhC2RNrWIg8hRYnclWpnZmx2zkiufQkmd3w==",
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -2097,7 +2104,7 @@
       "integrity": "sha512-zVipEeZQcBnOzpGQk4ngFbd+VUYJDWASnGpquHthSPta3Kcy33qOwAIx3hXRmDdp4d2zbm8licximJWbpEG1hA==",
       "dev": true,
       "requires": {
-        "webpack": "3.11.0"
+        "webpack": "^3.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -2106,9 +2113,9 @@
           "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "ajv-keywords": {
@@ -2135,9 +2142,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -2146,9 +2153,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -2159,7 +2166,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "has-flag": {
@@ -2174,10 +2181,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "loader-utils": {
@@ -2186,9 +2193,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
           }
         },
         "os-locale": {
@@ -2197,9 +2204,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "path-type": {
@@ -2208,7 +2215,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -2217,9 +2224,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -2228,8 +2235,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "string-width": {
@@ -2238,8 +2245,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -2254,7 +2261,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -2271,7 +2278,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "webpack": {
@@ -2280,28 +2287,28 @@
           "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
           "dev": true,
           "requires": {
-            "acorn": "5.4.1",
-            "acorn-dynamic-import": "2.0.2",
-            "ajv": "6.1.1",
-            "ajv-keywords": "3.1.0",
-            "async": "2.6.0",
-            "enhanced-resolve": "3.4.1",
-            "escope": "3.6.0",
-            "interpret": "1.1.0",
-            "json-loader": "0.5.7",
-            "json5": "0.5.1",
-            "loader-runner": "2.3.0",
-            "loader-utils": "1.1.0",
-            "memory-fs": "0.4.1",
-            "mkdirp": "0.5.1",
-            "node-libs-browser": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.5.0",
-            "tapable": "0.2.8",
-            "uglifyjs-webpack-plugin": "0.4.6",
-            "watchpack": "1.4.0",
-            "webpack-sources": "1.1.0",
-            "yargs": "8.0.2"
+            "acorn": "^5.0.0",
+            "acorn-dynamic-import": "^2.0.0",
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0",
+            "async": "^2.1.2",
+            "enhanced-resolve": "^3.4.0",
+            "escope": "^3.6.0",
+            "interpret": "^1.0.0",
+            "json-loader": "^0.5.4",
+            "json5": "^0.5.1",
+            "loader-runner": "^2.3.0",
+            "loader-utils": "^1.1.0",
+            "memory-fs": "~0.4.1",
+            "mkdirp": "~0.5.0",
+            "node-libs-browser": "^2.0.0",
+            "source-map": "^0.5.3",
+            "supports-color": "^4.2.1",
+            "tapable": "^0.2.7",
+            "uglifyjs-webpack-plugin": "^0.4.6",
+            "watchpack": "^1.4.0",
+            "webpack-sources": "^1.0.1",
+            "yargs": "^8.0.2"
           }
         },
         "which-module": {
@@ -2316,19 +2323,19 @@
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         },
         "yargs-parser": {
@@ -2337,7 +2344,7 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -2348,7 +2355,7 @@
       "integrity": "sha512-Gp/0/4cAH2g1rpcjiCngdxg7j6BKuFrvE1kWGSmnLjhRlbm1UW9/k923PbHKFIRP7oXMMio/lVeXAVsZZCEnrQ==",
       "dev": true,
       "requires": {
-        "webpack": "3.11.0"
+        "webpack": "^3.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -2357,9 +2364,9 @@
           "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "ajv-keywords": {
@@ -2386,9 +2393,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -2397,9 +2404,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -2410,7 +2417,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "has-flag": {
@@ -2425,10 +2432,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "loader-utils": {
@@ -2437,9 +2444,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
           }
         },
         "os-locale": {
@@ -2448,9 +2455,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "path-type": {
@@ -2459,7 +2466,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -2468,9 +2475,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -2479,8 +2486,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "string-width": {
@@ -2489,8 +2496,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -2505,7 +2512,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -2522,7 +2529,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "webpack": {
@@ -2531,28 +2538,28 @@
           "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
           "dev": true,
           "requires": {
-            "acorn": "5.4.1",
-            "acorn-dynamic-import": "2.0.2",
-            "ajv": "6.1.1",
-            "ajv-keywords": "3.1.0",
-            "async": "2.6.0",
-            "enhanced-resolve": "3.4.1",
-            "escope": "3.6.0",
-            "interpret": "1.1.0",
-            "json-loader": "0.5.7",
-            "json5": "0.5.1",
-            "loader-runner": "2.3.0",
-            "loader-utils": "1.1.0",
-            "memory-fs": "0.4.1",
-            "mkdirp": "0.5.1",
-            "node-libs-browser": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.5.0",
-            "tapable": "0.2.8",
-            "uglifyjs-webpack-plugin": "0.4.6",
-            "watchpack": "1.4.0",
-            "webpack-sources": "1.1.0",
-            "yargs": "8.0.2"
+            "acorn": "^5.0.0",
+            "acorn-dynamic-import": "^2.0.0",
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0",
+            "async": "^2.1.2",
+            "enhanced-resolve": "^3.4.0",
+            "escope": "^3.6.0",
+            "interpret": "^1.0.0",
+            "json-loader": "^0.5.4",
+            "json5": "^0.5.1",
+            "loader-runner": "^2.3.0",
+            "loader-utils": "^1.1.0",
+            "memory-fs": "~0.4.1",
+            "mkdirp": "~0.5.0",
+            "node-libs-browser": "^2.0.0",
+            "source-map": "^0.5.3",
+            "supports-color": "^4.2.1",
+            "tapable": "^0.2.7",
+            "uglifyjs-webpack-plugin": "^0.4.6",
+            "watchpack": "^1.4.0",
+            "webpack-sources": "^1.0.1",
+            "yargs": "^8.0.2"
           }
         },
         "which-module": {
@@ -2567,19 +2574,19 @@
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         },
         "yargs-parser": {
@@ -2588,7 +2595,7 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -2598,8 +2605,8 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz",
       "integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
       "requires": {
-        "ethereum-common": "0.0.18",
-        "ethereumjs-util": "5.1.4"
+        "ethereum-common": "^0.0.18",
+        "ethereumjs-util": "^5.0.0"
       },
       "dependencies": {
         "ethereum-common": {
@@ -2612,13 +2619,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.4.tgz",
           "integrity": "sha512-wbeTc5prEzIWFSQUcEsCAZbqubtJKy6yS+oZMY1cGG6GLYzLjm4YhC2RNrWIg8hRYnclWpnZmx2zkiufQkmd3w==",
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -2628,11 +2635,11 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
       "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
       "requires": {
-        "bn.js": "4.11.8",
-        "create-hash": "1.1.3",
-        "keccakjs": "0.2.1",
-        "rlp": "2.0.0",
-        "secp256k1": "3.5.0"
+        "bn.js": "^4.8.0",
+        "create-hash": "^1.1.2",
+        "keccakjs": "^0.2.0",
+        "rlp": "^2.0.0",
+        "secp256k1": "^3.0.1"
       }
     },
     "ethereumjs-vm": {
@@ -2640,17 +2647,17 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.3.tgz",
       "integrity": "sha512-yIWJqTEcrF9vJTCvNMxacRkAx6zIZTOW0SmSA+hSFiU1x8JyVZDi9o5udwsRVECT5RkPgQzm62kpL6Pf4qemsw==",
       "requires": {
-        "async": "2.6.0",
-        "async-eventemitter": "0.2.4",
+        "async": "^2.1.2",
+        "async-eventemitter": "^0.2.2",
         "ethereum-common": "0.2.0",
-        "ethereumjs-account": "2.0.4",
-        "ethereumjs-block": "1.7.1",
-        "ethereumjs-util": "5.1.4",
-        "fake-merkle-patricia-tree": "1.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "merkle-patricia-tree": "2.3.0",
-        "rustbn.js": "0.1.2",
-        "safe-buffer": "5.1.1"
+        "ethereumjs-account": "^2.0.3",
+        "ethereumjs-block": "~1.7.0",
+        "ethereumjs-util": "^5.1.3",
+        "fake-merkle-patricia-tree": "^1.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "merkle-patricia-tree": "^2.1.2",
+        "rustbn.js": "~0.1.1",
+        "safe-buffer": "^5.1.1"
       },
       "dependencies": {
         "ethereumjs-util": {
@@ -2658,13 +2665,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.4.tgz",
           "integrity": "sha512-wbeTc5prEzIWFSQUcEsCAZbqubtJKy6yS+oZMY1cGG6GLYzLjm4YhC2RNrWIg8hRYnclWpnZmx2zkiufQkmd3w==",
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -2674,13 +2681,13 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz",
       "integrity": "sha1-gnY7Fpfuenlr5xVdqd+0my+Yz9s=",
       "requires": {
-        "aes-js": "0.2.4",
-        "bs58check": "1.3.4",
-        "ethereumjs-util": "4.5.0",
-        "hdkey": "0.7.1",
-        "scrypt.js": "0.2.0",
-        "utf8": "2.1.2",
-        "uuid": "2.0.3"
+        "aes-js": "^0.2.3",
+        "bs58check": "^1.0.8",
+        "ethereumjs-util": "^4.4.0",
+        "hdkey": "^0.7.0",
+        "scrypt.js": "^0.2.0",
+        "utf8": "^2.1.1",
+        "uuid": "^2.0.1"
       }
     },
     "ethjs-abi": {
@@ -2736,8 +2743,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter3": {
@@ -2755,8 +2762,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -2765,13 +2772,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -2779,7 +2786,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -2787,7 +2794,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "express": {
@@ -2795,36 +2802,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "~2.0.2",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.1",
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.16",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "setprototypeof": {
@@ -2849,7 +2856,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -2862,7 +2869,7 @@
       "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
       "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
       "requires": {
-        "checkpoint-store": "1.1.0"
+        "checkpoint-store": "^1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -2886,7 +2893,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "file-type": {
@@ -2904,11 +2911,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -2917,12 +2924,12 @@
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -2937,9 +2944,9 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
       "requires": {
-        "commondir": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pkg-dir": "1.0.0"
+        "commondir": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pkg-dir": "^1.0.0"
       }
     },
     "find-up": {
@@ -2947,8 +2954,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "for-each": {
@@ -2956,7 +2963,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "requires": {
-        "is-function": "1.0.1"
+        "is-function": "~1.0.0"
       }
     },
     "for-in": {
@@ -2969,7 +2976,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -2987,9 +2994,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -3007,11 +3014,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs-promise": {
@@ -3019,10 +3026,10 @@
       "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
       "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
       "requires": {
-        "any-promise": "1.3.0",
-        "fs-extra": "2.1.2",
-        "mz": "2.7.0",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.3.0",
+        "fs-extra": "^2.0.0",
+        "mz": "^2.6.0",
+        "thenify-all": "^1.6.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -3030,8 +3037,8 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
           }
         }
       }
@@ -3047,8 +3054,8 @@
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -3279,9 +3286,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -3504,17 +3511,17 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "^1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -3753,9 +3760,9 @@
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -3763,14 +3770,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -3835,10 +3842,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -3863,7 +3870,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -3881,7 +3888,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -3889,12 +3896,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -3902,8 +3909,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -3911,7 +3918,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global": {
@@ -3919,8 +3926,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       },
       "dependencies": {
         "process": {
@@ -3940,20 +3947,20 @@
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
       "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "requires": {
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-plain-obj": "1.1.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.0",
-        "p-cancelable": "0.3.0",
-        "p-timeout": "1.2.1",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "1.0.0",
-        "url-to-options": "1.0.1"
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "graceful-fs": {
@@ -3978,10 +3985,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -3996,7 +4003,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -4011,8 +4018,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -4020,10 +4027,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         }
       }
@@ -4033,7 +4040,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -4041,7 +4048,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -4059,7 +4066,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "1.4.1"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "hash-base": {
@@ -4067,7 +4074,7 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -4075,8 +4082,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -4084,10 +4091,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hdkey": {
@@ -4095,8 +4102,8 @@
       "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
       "integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
       "requires": {
-        "coinstring": "2.3.0",
-        "secp256k1": "3.5.0"
+        "coinstring": "^2.0.0",
+        "secp256k1": "^3.0.1"
       }
     },
     "he": {
@@ -4110,9 +4117,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -4125,8 +4132,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -4142,7 +4149,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.3.1 < 2"
       },
       "dependencies": {
         "depd": {
@@ -4162,9 +4169,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -4197,8 +4204,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -4216,7 +4223,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -4239,7 +4246,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -4252,7 +4259,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -4275,7 +4282,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -4293,7 +4300,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4301,7 +4308,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -4314,7 +4321,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-hex-prefixed": {
@@ -4334,11 +4341,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-natural-number": {
@@ -4351,7 +4358,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-object": {
@@ -4385,7 +4392,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-retry-allowed": {
@@ -4437,8 +4444,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -4452,20 +4459,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.6.1",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "async": {
@@ -4480,11 +4487,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "resolve": {
@@ -4499,7 +4506,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "wordwrap": {
@@ -4515,8 +4522,8 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "jade": {
@@ -4559,8 +4566,8 @@
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
       }
     },
     "jsbn": {
@@ -4594,7 +4601,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -4618,7 +4625,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -4648,10 +4655,10 @@
       "resolved": "https://registry.npmjs.org/jsverify/-/jsverify-0.8.3.tgz",
       "integrity": "sha1-AukXjhkktar5WcAjmvhO1cbQc4w=",
       "requires": {
-        "lazy-seq": "1.0.0",
-        "rc4": "0.1.5",
-        "trampa": "1.0.0",
-        "typify-parser": "1.1.0"
+        "lazy-seq": "^1.0.0",
+        "rc4": "~0.1.5",
+        "trampa": "^1.0.0",
+        "typify-parser": "^1.1.0"
       }
     },
     "keccak": {
@@ -4659,10 +4666,10 @@
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
       "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "requires": {
-        "bindings": "1.3.0",
-        "inherits": "2.0.3",
-        "nan": "2.8.0",
-        "safe-buffer": "5.1.1"
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
       }
     },
     "keccakjs": {
@@ -4670,8 +4677,8 @@
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
       "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
       "requires": {
-        "browserify-sha3": "0.0.1",
-        "sha3": "1.2.0"
+        "browserify-sha3": "^0.0.1",
+        "sha3": "^1.1.0"
       }
     },
     "kind-of": {
@@ -4679,7 +4686,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -4687,7 +4694,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazy-cache": {
@@ -4705,7 +4712,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -4724,7 +4731,7 @@
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
@@ -4732,10 +4739,10 @@
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
-        "inherits": "2.0.3",
-        "level-errors": "1.0.5",
-        "readable-stream": "1.1.14",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "level-errors": "^1.0.3",
+        "readable-stream": "^1.0.33",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -4748,10 +4755,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -4766,8 +4773,8 @@
       "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
       "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "2.1.2"
+        "readable-stream": "~1.0.15",
+        "xtend": "~2.1.1"
       },
       "dependencies": {
         "isarray": {
@@ -4780,10 +4787,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -4796,7 +4803,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -4806,13 +4813,13 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
       "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "requires": {
-        "deferred-leveldown": "1.2.2",
-        "level-codec": "7.0.1",
-        "level-errors": "1.0.5",
-        "level-iterator-stream": "1.3.1",
-        "prr": "1.0.1",
-        "semver": "5.4.1",
-        "xtend": "4.0.1"
+        "deferred-leveldown": "~1.2.1",
+        "level-codec": "~7.0.0",
+        "level-errors": "~1.0.3",
+        "level-iterator-stream": "~1.3.0",
+        "prr": "~1.0.1",
+        "semver": "~5.4.1",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "semver": {
@@ -4828,8 +4835,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -4837,11 +4844,11 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "loader-runner": {
@@ -4854,10 +4861,10 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
       }
     },
     "locate-path": {
@@ -4866,8 +4873,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -4889,8 +4896,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -4928,9 +4935,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -4951,9 +4958,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "log-driver": {
@@ -4972,7 +4979,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -4986,8 +4993,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "ltgt": {
@@ -5000,7 +5007,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5015,8 +5022,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -5024,8 +5031,8 @@
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -5041,7 +5048,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memdown": {
@@ -5049,12 +5056,12 @@
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
       "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "requires": {
-        "abstract-leveldown": "2.7.2",
-        "functional-red-black-tree": "1.0.1",
-        "immediate": "3.2.3",
-        "inherits": "2.0.3",
-        "ltgt": "2.2.0",
-        "safe-buffer": "5.1.1"
+        "abstract-leveldown": "~2.7.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.1.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -5062,7 +5069,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
           "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "requires": {
-            "xtend": "4.0.1"
+            "xtend": "~4.0.0"
           }
         }
       }
@@ -5072,8 +5079,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.4"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "memorystream": {
@@ -5091,14 +5098,14 @@
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.0.tgz",
       "integrity": "sha512-LKd2OoIT9Re/OG38zXbd5pyHIk2IfcOUczCwkYXl5iJIbufg9nqpweh66VfPwMkUlrEvc7YVvtQdmSrB9V9TkQ==",
       "requires": {
-        "async": "1.5.2",
-        "ethereumjs-util": "5.1.4",
+        "async": "^1.4.2",
+        "ethereumjs-util": "^5.0.0",
         "level-ws": "0.0.0",
-        "levelup": "1.3.9",
-        "memdown": "1.4.1",
-        "readable-stream": "2.3.4",
-        "rlp": "2.0.0",
-        "semaphore": "1.1.0"
+        "levelup": "^1.2.1",
+        "memdown": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "rlp": "^2.0.0",
+        "semaphore": ">=1.0.1"
       },
       "dependencies": {
         "async": {
@@ -5111,13 +5118,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.4.tgz",
           "integrity": "sha512-wbeTc5prEzIWFSQUcEsCAZbqubtJKy6yS+oZMY1cGG6GLYzLjm4YhC2RNrWIg8hRYnclWpnZmx2zkiufQkmd3w==",
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -5132,19 +5139,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -5152,8 +5159,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -5171,7 +5178,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -5190,7 +5197,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -5208,7 +5215,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -5229,7 +5236,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
       "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "*"
       }
     },
     "mocha": {
@@ -5277,8 +5284,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "lru-cache": {
@@ -5293,8 +5300,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "ms": {
@@ -5336,9 +5343,9 @@
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "nan": {
@@ -5361,8 +5368,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-libs-browser": {
@@ -5370,28 +5377,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.4",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.6",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       }
     },
@@ -5401,7 +5408,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -5409,10 +5416,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -5420,7 +5427,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -5429,7 +5436,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -5478,8 +5485,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "oboe": {
@@ -5487,7 +5494,7 @@
       "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
       "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
       "requires": {
-        "http-https": "1.0.0"
+        "http-https": "^1.0.0"
       }
     },
     "on-finished": {
@@ -5503,7 +5510,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -5512,8 +5519,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.2"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -5522,12 +5529,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -5559,7 +5566,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -5583,7 +5590,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -5592,7 +5599,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-timeout": {
@@ -5600,7 +5607,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -5619,11 +5626,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -5631,10 +5638,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-headers": {
@@ -5642,7 +5649,7 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "0.3.2",
+        "for-each": "^0.3.2",
         "trim": "0.0.1"
       }
     },
@@ -5651,7 +5658,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parseurl": {
@@ -5669,7 +5676,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -5698,9 +5705,9 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pbkdf2": {
@@ -5708,11 +5715,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pegjs": {
@@ -5746,7 +5753,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -5754,7 +5761,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "prelude-ls": {
@@ -5793,7 +5800,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
       }
     },
@@ -5813,11 +5820,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -5835,9 +5842,9 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz",
       "integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ==",
       "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -5855,8 +5862,8 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5864,7 +5871,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5872,7 +5879,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5882,7 +5889,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5892,7 +5899,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -5900,8 +5907,8 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomhex": {
@@ -5935,9 +5942,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -5945,8 +5952,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -5954,13 +5961,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -5968,10 +5975,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.4",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "rechoir": {
@@ -5980,7 +5987,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "regenerate": {
@@ -5998,9 +6005,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -6008,7 +6015,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpu-core": {
@@ -6016,9 +6023,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -6031,7 +6038,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -6061,7 +6068,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "req-cwd": {
@@ -6070,7 +6077,7 @@
       "integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
       "dev": true,
       "requires": {
-        "req-from": "1.0.1"
+        "req-from": "^1.0.1"
       }
     },
     "req-from": {
@@ -6079,7 +6086,7 @@
       "integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
       "dev": true,
       "requires": {
-        "resolve-from": "2.0.0"
+        "resolve-from": "^2.0.0"
       }
     },
     "request": {
@@ -6087,28 +6094,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "uuid": {
@@ -6138,7 +6145,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -6152,7 +6159,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "right-align": {
@@ -6160,7 +6167,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -6168,7 +6175,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -6176,8 +6183,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rlp": {
@@ -6200,7 +6207,7 @@
       "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
       "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
       "requires": {
-        "nan": "2.8.0"
+        "nan": "^2.0.8"
       }
     },
     "scrypt.js": {
@@ -6208,8 +6215,8 @@
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
       "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
       "requires": {
-        "scrypt": "6.0.3",
-        "scryptsy": "1.2.1"
+        "scrypt": "^6.0.2",
+        "scryptsy": "^1.2.1"
       }
     },
     "scryptsy": {
@@ -6217,7 +6224,7 @@
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
       "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
       "requires": {
-        "pbkdf2": "3.0.14"
+        "pbkdf2": "^3.0.3"
       }
     },
     "secp256k1": {
@@ -6225,14 +6232,14 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
       "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
       "requires": {
-        "bindings": "1.3.0",
-        "bip66": "1.1.5",
-        "bn.js": "4.11.8",
-        "create-hash": "1.1.3",
-        "drbg.js": "1.0.1",
-        "elliptic": "6.4.0",
-        "nan": "2.8.0",
-        "safe-buffer": "5.1.1"
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
       }
     },
     "seek-bzip": {
@@ -6240,7 +6247,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       }
     },
     "semaphore": {
@@ -6259,18 +6266,18 @@
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       },
       "dependencies": {
         "statuses": {
@@ -6285,9 +6292,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.1"
       }
     },
@@ -6296,11 +6303,11 @@
       "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
       "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
       "requires": {
-        "body-parser": "1.18.2",
-        "cors": "2.8.4",
-        "express": "4.16.2",
-        "request": "2.83.0",
-        "xhr": "2.4.1"
+        "body-parser": "^1.16.0",
+        "cors": "^2.8.1",
+        "express": "^4.14.0",
+        "request": "^2.79.0",
+        "xhr": "^2.3.3"
       }
     },
     "set-blocking": {
@@ -6328,8 +6335,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
       "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "sha3": {
@@ -6337,7 +6344,7 @@
       "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.0.tgz",
       "integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
       "requires": {
-        "nan": "2.8.0"
+        "nan": "^2.0.5"
       }
     },
     "shebang-command": {
@@ -6346,7 +6353,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -6361,9 +6368,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "sigmund": {
@@ -6388,9 +6395,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
       "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "slash": {
@@ -6403,7 +6410,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "sol-explore": {
@@ -6417,11 +6424,11 @@
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.20.tgz",
       "integrity": "sha512-LrP3Jp4FS3y8sduIR67y8Ss1riR3fggk5sMnx4OSCcU88Ro0e51+KVXyfH3NP6ghLo7COrLx/lGUaDDugCzdgA==",
       "requires": {
-        "fs-extra": "0.30.0",
-        "memorystream": "0.3.1",
-        "require-from-string": "1.2.1",
-        "semver": "5.5.0",
-        "yargs": "4.8.1"
+        "fs-extra": "^0.30.0",
+        "memorystream": "^0.3.1",
+        "require-from-string": "^1.1.0",
+        "semver": "^5.3.0",
+        "yargs": "^4.7.1"
       },
       "dependencies": {
         "camelcase": {
@@ -6434,9 +6441,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "window-size": {
@@ -6449,20 +6456,20 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "lodash.assign": "4.2.0",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "2.4.1"
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
           }
         },
         "yargs-parser": {
@@ -6470,8 +6477,8 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
           }
         }
       }
@@ -6482,15 +6489,15 @@
       "integrity": "sha512-+AfMnKcCENZIKMLh2Ew6rO+cME0ZtJVfmfdy1X3ywmAH1WTTRy3ZVgDRgZgEy2n8fHhalbcZp7mTrzMd0IGoTw==",
       "dev": true,
       "requires": {
-        "death": "1.1.0",
+        "death": "^1.1.0",
         "ethereumjs-testrpc-sc": "4.0.2",
-        "istanbul": "0.4.5",
-        "keccakjs": "0.2.1",
-        "req-cwd": "1.0.1",
-        "shelljs": "0.7.8",
-        "sol-explore": "1.6.2",
+        "istanbul": "^0.4.5",
+        "keccakjs": "^0.2.1",
+        "req-cwd": "^1.0.1",
+        "shelljs": "^0.7.4",
+        "sol-explore": "^1.6.2",
         "solidity-parser-sc": "0.4.1",
-        "web3": "0.18.4"
+        "web3": "^0.18.4"
       },
       "dependencies": {
         "web3": {
@@ -6508,15 +6515,83 @@
         }
       }
     },
+    "solidity-parser": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/solidity-parser/-/solidity-parser-0.4.0.tgz",
+      "integrity": "sha1-o0PxPac8kWgyeQNGgOgMSR3jQPo=",
+      "dev": true,
+      "requires": {
+        "mocha": "^2.4.5",
+        "pegjs": "^0.10.0",
+        "yargs": "^4.6.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "dev": true,
+          "requires": {
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
+          }
+        }
+      }
+    },
     "solidity-parser-sc": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
       "integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
       "dev": true,
       "requires": {
-        "mocha": "2.5.3",
-        "pegjs": "0.10.0",
-        "yargs": "4.8.1"
+        "mocha": "^2.4.5",
+        "pegjs": "^0.10.0",
+        "yargs": "^4.6.0"
       },
       "dependencies": {
         "camelcase": {
@@ -6576,6 +6651,94 @@
         }
       }
     },
+    "solmd": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/solmd/-/solmd-0.2.3.tgz",
+      "integrity": "sha1-sgSh9V+m0UysVWZILjlSEyLZsgk=",
+      "dev": true,
+      "requires": {
+        "dot": "^1.1.2",
+        "keccakjs": "^0.2.1",
+        "minimist": "^1.2.0",
+        "solc": "^0.4.23"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "solc": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
+          "integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "^0.30.0",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^1.1.0",
+            "semver": "^5.3.0",
+            "yargs": "^4.7.1"
+          }
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "dev": true,
+          "requires": {
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
+          }
+        }
+      }
+    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -6591,7 +6754,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "spdx-correct": {
@@ -6599,7 +6762,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -6623,14 +6786,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "statuses": {
@@ -6643,8 +6806,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-http": {
@@ -6652,11 +6815,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
       "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "strict-uri-encode": {
@@ -6669,9 +6832,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.trim": {
@@ -6679,9 +6842,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -6689,7 +6852,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -6702,7 +6865,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -6710,7 +6873,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-dirs": {
@@ -6718,7 +6881,7 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "requires": {
-        "is-natural-number": "4.0.1"
+        "is-natural-number": "^4.0.1"
       }
     },
     "strip-eof": {
@@ -6745,19 +6908,19 @@
       "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
       "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
       "requires": {
-        "bluebird": "3.5.1",
-        "buffer": "5.1.0",
-        "decompress": "4.2.0",
-        "eth-lib": "0.1.27",
-        "fs-extra": "2.1.2",
-        "fs-promise": "2.0.3",
-        "got": "7.1.0",
-        "mime-types": "2.1.18",
-        "mkdirp-promise": "5.0.1",
-        "mock-fs": "4.4.2",
-        "setimmediate": "1.0.5",
-        "tar.gz": "1.0.7",
-        "xhr-request-promise": "0.1.2"
+        "bluebird": "^3.5.0",
+        "buffer": "^5.0.5",
+        "decompress": "^4.0.0",
+        "eth-lib": "^0.1.26",
+        "fs-extra": "^2.1.2",
+        "fs-promise": "^2.0.0",
+        "got": "^7.1.0",
+        "mime-types": "^2.1.16",
+        "mkdirp-promise": "^5.0.1",
+        "mock-fs": "^4.1.0",
+        "setimmediate": "^1.0.5",
+        "tar.gz": "^1.0.5",
+        "xhr-request-promise": "^0.1.2"
       },
       "dependencies": {
         "buffer": {
@@ -6765,8 +6928,8 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
           "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
           "requires": {
-            "base64-js": "1.2.3",
-            "ieee754": "1.1.8"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         },
         "fs-extra": {
@@ -6774,8 +6937,8 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
           }
         }
       }
@@ -6790,19 +6953,19 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
       "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.5.0",
-        "resolve": "1.5.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.2",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.2",
+        "has": "~1.0.1",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.5.0",
+        "resolve": "~1.5.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
         "minimist": {
@@ -6817,9 +6980,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-stream": {
@@ -6827,10 +6990,10 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.4",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "tar.gz": {
@@ -6838,11 +7001,11 @@
       "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
       "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
       "requires": {
-        "bluebird": "2.11.0",
-        "commander": "2.8.1",
-        "fstream": "1.0.11",
-        "mout": "0.11.1",
-        "tar": "2.2.1"
+        "bluebird": "^2.9.34",
+        "commander": "^2.8.1",
+        "fstream": "^1.0.8",
+        "mout": "^0.11.0",
+        "tar": "^2.1.1"
       },
       "dependencies": {
         "bluebird": {
@@ -6857,7 +7020,7 @@
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -6865,7 +7028,7 @@
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "through": {
@@ -6883,7 +7046,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
       "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "to-arraybuffer": {
@@ -6907,7 +7070,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trampa": {
@@ -6931,8 +7094,8 @@
       "integrity": "sha512-Hyj4LFRdfgoeb1SVV17hLAlO/szCXuuWS3tq26N5BI+avcEYdZl4KhxKMVgf6O/HeEIEuDYCpfLOWplXMfjeHQ==",
       "dev": true,
       "requires": {
-        "mocha": "3.5.3",
-        "original-require": "1.0.1",
+        "mocha": "^3.4.2",
+        "original-require": "^1.0.1",
         "solc": "0.4.18"
       },
       "dependencies": {
@@ -7017,11 +7180,11 @@
           "integrity": "sha512-Kq+O3PNF9Pfq7fB+lDYAuoqRdghLmZyfngsg0h1Hj38NKAeVHeGPOGeZasn5KqdPeCzbMFvaGyTySxzGv6aXCg==",
           "dev": true,
           "requires": {
-            "fs-extra": "0.30.0",
-            "memorystream": "0.3.1",
-            "require-from-string": "1.2.1",
-            "semver": "5.5.0",
-            "yargs": "4.8.1"
+            "fs-extra": "^0.30.0",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^1.1.0",
+            "semver": "^5.3.0",
+            "yargs": "^4.7.1"
           }
         },
         "supports-color": {
@@ -7079,11 +7242,12 @@
       "integrity": "sha1-rooRHsEk2WUE8OBCxvIFwLOBfik=",
       "dev": true,
       "requires": {
-        "web3": "0.20.5"
+        "web3": "^0.20.1"
       },
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
           "dev": true
         },
         "web3": {
@@ -7093,10 +7257,34 @@
           "dev": true,
           "requires": {
             "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xhr2": "0.1.4",
-            "xmlhttprequest": "1.8.0"
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
+          }
+        }
+      }
+    },
+    "truffle-config": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.4.tgz",
+      "integrity": "sha512-E8pvJNAIjs7LNsjkYeS2dgoOnLoSBrTwb1xF5lJwfvZmGMFpKvVL1sa5jpFxozpf/WkRn/rfxy8zTdb3pq16jA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0",
+        "lodash": "^4.17.4",
+        "original-require": "^1.0.0",
+        "truffle-error": "^0.0.2",
+        "truffle-provider": "^0.0.4"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -7108,10 +7296,10 @@
       "dev": true,
       "requires": {
         "ethjs-abi": "0.1.8",
-        "truffle-blockchain-utils": "0.0.3",
-        "truffle-contract-schema": "1.0.1",
+        "truffle-blockchain-utils": "^0.0.3",
+        "truffle-contract-schema": "^1.0.0",
         "truffle-error": "0.0.2",
-        "web3": "0.20.5"
+        "web3": "^0.20.1"
       },
       "dependencies": {
         "bignumber.js": {
@@ -7148,10 +7336,10 @@
           "dev": true,
           "requires": {
             "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xhr2": "0.1.4",
-            "xmlhttprequest": "1.8.0"
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
           }
         }
       }
@@ -7162,8 +7350,8 @@
       "integrity": "sha512-37ZO9FVvmW/PZz/sh00LAz7HN2U4FHERuxI4mCbUR6h3r2cRgZ4YBfzHuAHOnZlrVzM1qx/Dx/1Ng3UyfWseEA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "crypto-js": "3.1.9-1"
+        "ajv": "^5.1.1",
+        "crypto-js": "^3.1.9-1"
       },
       "dependencies": {
         "ajv": {
@@ -7192,15 +7380,46 @@
       "integrity": "sha1-AbGJt4UFVmrhaJwjnHyi3RIc/kw=",
       "dev": true
     },
+    "truffle-expect": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-expect/-/truffle-expect-0.0.3.tgz",
+      "integrity": "sha1-m3XO80O9WW5+XbyHj18bLjGKlEw=",
+      "dev": true
+    },
+    "truffle-flattener": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.2.5.tgz",
+      "integrity": "sha512-5zq1xPghIpET8QmWl0rKSgf2uiq+2UA2HVwbexNtzd0z3AIuOvOqAbZhjuOWMuyNvx8jLDhzjyThvowOeouajQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0",
+        "semver": "^5.4.1",
+        "solidity-parser": "^0.4.0",
+        "truffle-config": "^1.0.2",
+        "truffle-resolver": "^4.0.1",
+        "tsort": "0.0.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
+      }
+    },
     "truffle-hdwallet-provider": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-0.0.3.tgz",
       "integrity": "sha1-Dh3gIQS3PTh14c9wkzBbTqii2EM=",
       "requires": {
-        "bip39": "2.5.0",
-        "ethereumjs-wallet": "0.6.0",
-        "web3": "0.18.4",
-        "web3-provider-engine": "8.6.1"
+        "bip39": "^2.2.0",
+        "ethereumjs-wallet": "^0.6.0",
+        "web3": "^0.18.2",
+        "web3-provider-engine": "^8.4.0"
       },
       "dependencies": {
         "web3": {
@@ -7209,13 +7428,175 @@
           "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
           "requires": {
             "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xhr2": "0.1.4",
-            "xmlhttprequest": "1.8.0"
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
           }
         }
       }
+    },
+    "truffle-provider": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.4.tgz",
+      "integrity": "sha512-yVxxjocxnJcFspQ0T4Rjq/1wvvm3iLxidb6oa1EAX5LsnSQLPG8wAM5+JLlJ4FDBsqJdZLGOq1RR5Ln/w7x5JA==",
+      "dev": true,
+      "requires": {
+        "truffle-error": "^0.0.2",
+        "web3": "^0.20.1"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+          "dev": true
+        },
+        "web3": {
+          "version": "0.20.6",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
+          }
+        }
+      }
+    },
+    "truffle-provisioner": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.0.tgz",
+      "integrity": "sha1-Ap5SScEBUwBzhTXgT97ZMaU8T2I=",
+      "dev": true
+    },
+    "truffle-resolver": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-resolver/-/truffle-resolver-4.0.3.tgz",
+      "integrity": "sha512-CXzfXcG6LxQm5cWXH/HJE85pnvHvPDB16l2pzk9/q1F9Y4BWD2xS4rYzvrXGjkPNGrYTkNY+baF5YN/6eIGGgQ==",
+      "dev": true,
+      "requires": {
+        "async": "^2.1.4",
+        "truffle-contract": "^3.0.5",
+        "truffle-expect": "0.0.3",
+        "truffle-provisioner": "^0.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "crypto-js": {
+          "version": "3.1.9-1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+          "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ethjs-abi": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
+          "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "js-sha3": "0.5.5",
+            "number-to-bn": "1.7.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
+        },
+        "truffle-blockchain-utils": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.4.tgz",
+          "integrity": "sha512-wgRrhwqh0aea08Hz28hUV4tuF2uTVQH/e9kBou+WK04cqrutB5cxQVQ6HGjeZLltxBYOFvhrGOOq4l3WJFnPEA==",
+          "dev": true
+        },
+        "truffle-contract": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.5.tgz",
+          "integrity": "sha512-lRayhvX73OrLJ6TDvc0iYbzcB+Y1F9FCj9N1FXQ2EKOkqyIjmgZNMZFHGjvfTws1gsmonYd6sND0ahipiUYy8g==",
+          "dev": true,
+          "requires": {
+            "ethjs-abi": "0.1.8",
+            "truffle-blockchain-utils": "^0.0.4",
+            "truffle-contract-schema": "^2.0.0",
+            "truffle-error": "0.0.2",
+            "web3": "^0.20.1"
+          }
+        },
+        "truffle-contract-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.0.tgz",
+          "integrity": "sha512-nLlspmu1GKDaluWksBwitHi/7Z3IpRjmBYeO9N+T1nVJD2V4IWJaptCKP1NqnPiJA+FChB7+F7pI6Br51/FtXQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.1.1",
+            "crypto-js": "^3.1.9-1",
+            "debug": "^3.1.0"
+          }
+        },
+        "web3": {
+          "version": "0.20.6",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "crypto-js": {
+              "version": "3.1.8",
+              "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
+              "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "tsort": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
+      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y=",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -7227,7 +7608,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -7242,7 +7623,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -7256,7 +7637,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray-to-buffer": {
@@ -7264,7 +7645,7 @@
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
       "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
       "requires": {
-        "is-typedarray": "1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "typify-parser": {
@@ -7277,9 +7658,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "yargs": {
@@ -7287,9 +7668,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -7307,9 +7688,9 @@
       "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-js": "2.8.29",
-        "webpack-sources": "1.1.0"
+        "source-map": "^0.5.6",
+        "uglify-js": "^2.8.29",
+        "webpack-sources": "^1.0.1"
       }
     },
     "ultron": {
@@ -7322,8 +7703,8 @@
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
       "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
       "requires": {
-        "buffer": "3.6.0",
-        "through": "2.3.8"
+        "buffer": "^3.0.1",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "base64-js": {
@@ -7337,8 +7718,8 @@
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "requires": {
             "base64-js": "0.0.8",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         }
       }
@@ -7379,7 +7760,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-set-query": {
@@ -7432,8 +7813,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "vary": {
@@ -7446,9 +7827,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -7464,9 +7845,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "requires": {
-        "async": "2.6.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
+        "async": "^2.1.2",
+        "chokidar": "^1.7.0",
+        "graceful-fs": "^4.1.2"
       }
     },
     "web3": {
@@ -7607,7 +7988,7 @@
       "integrity": "sha1-jwobNCxCg4EjciQqbi3yaIh7O3A=",
       "requires": {
         "bluebird": "3.3.1",
-        "crypto-browserify": "3.12.0",
+        "crypto-browserify": "^3.12.0",
         "eth-lib": "0.2.7",
         "scrypt.js": "0.2.0",
         "underscore": "1.8.3",
@@ -7660,7 +8041,7 @@
       "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.30.tgz",
       "integrity": "sha1-OwgKXE2h+jdHexfkyQB4G5IVBkU=",
       "requires": {
-        "bn.js": "4.11.8",
+        "bn.js": "^4.11.6",
         "web3-utils": "1.0.0-beta.30"
       }
     },
@@ -7691,37 +8072,38 @@
       "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
       "integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
       "requires": {
-        "async": "2.6.0",
-        "clone": "2.1.1",
-        "ethereumjs-block": "1.7.1",
-        "ethereumjs-tx": "1.3.3",
-        "ethereumjs-util": "5.1.4",
-        "ethereumjs-vm": "2.3.3",
-        "isomorphic-fetch": "2.2.1",
-        "request": "2.83.0",
-        "semaphore": "1.1.0",
-        "solc": "0.4.20",
-        "tape": "4.9.0",
-        "web3": "0.16.0",
-        "xhr": "2.4.1",
-        "xtend": "4.0.1"
+        "async": "^2.1.2",
+        "clone": "^2.0.0",
+        "ethereumjs-block": "^1.2.2",
+        "ethereumjs-tx": "^1.2.0",
+        "ethereumjs-util": "^5.0.1",
+        "ethereumjs-vm": "^2.0.2",
+        "isomorphic-fetch": "^2.2.0",
+        "request": "^2.67.0",
+        "semaphore": "^1.0.3",
+        "solc": "^0.4.2",
+        "tape": "^4.4.0",
+        "web3": "^0.16.0",
+        "xhr": "^2.2.0",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+          "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
         },
         "ethereumjs-util": {
           "version": "5.1.4",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.4.tgz",
           "integrity": "sha512-wbeTc5prEzIWFSQUcEsCAZbqubtJKy6yS+oZMY1cGG6GLYzLjm4YhC2RNrWIg8hRYnclWpnZmx2zkiufQkmd3w==",
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         },
         "web3": {
@@ -7730,9 +8112,9 @@
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
             "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xmlhttprequest": "1.8.0"
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xmlhttprequest": "*"
           }
         }
       }
@@ -7783,7 +8165,7 @@
       "integrity": "sha1-6uQIzI1tb+zI1Ql8/q1Rdz8jH/k=",
       "requires": {
         "bn.js": "4.11.6",
-        "eth-lib": "0.1.27",
+        "eth-lib": "^0.1.27",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randomhex": "0.1.5",
@@ -7808,27 +8190,27 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
       "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
       "requires": {
-        "acorn": "5.4.1",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "0.2.17",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "3.2.3",
-        "tapable": "0.2.8",
-        "uglify-js": "2.8.29",
-        "watchpack": "1.4.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "6.6.0"
+        "acorn": "^5.0.0",
+        "acorn-dynamic-import": "^2.0.0",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.1.1",
+        "async": "^2.1.2",
+        "enhanced-resolve": "^3.3.0",
+        "interpret": "^1.0.0",
+        "json-loader": "^0.5.4",
+        "json5": "^0.5.1",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^0.2.16",
+        "memory-fs": "~0.4.1",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^2.0.0",
+        "source-map": "^0.5.3",
+        "supports-color": "^3.1.0",
+        "tapable": "~0.2.5",
+        "uglify-js": "^2.8.27",
+        "watchpack": "^1.3.1",
+        "webpack-sources": "^1.0.1",
+        "yargs": "^6.0.0"
       },
       "dependencies": {
         "supports-color": {
@@ -7836,7 +8218,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -7846,8 +8228,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -7859,11 +8241,12 @@
     },
     "websocket": {
       "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+      "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
       "requires": {
-        "debug": "2.6.9",
-        "nan": "2.8.0",
-        "typedarray-to-buffer": "3.1.2",
-        "yaeti": "0.0.6"
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       }
     },
     "whatwg-fetch": {
@@ -7877,7 +8260,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -7900,8 +8283,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -7914,9 +8297,9 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xhr": {
@@ -7924,10 +8307,10 @@
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
       "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
       "requires": {
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "parse-headers": "2.0.1",
-        "xtend": "4.0.1"
+        "global": "~4.3.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "xhr-request": {
@@ -7935,13 +8318,13 @@
       "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
       "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
       "requires": {
-        "buffer-to-arraybuffer": "0.0.5",
-        "object-assign": "4.1.1",
-        "query-string": "5.1.0",
-        "simple-get": "2.7.0",
-        "timed-out": "4.0.1",
-        "url-set-query": "1.0.0",
-        "xhr": "2.4.1"
+        "buffer-to-arraybuffer": "^0.0.5",
+        "object-assign": "^4.1.1",
+        "query-string": "^5.0.1",
+        "simple-get": "^2.7.0",
+        "timed-out": "^4.0.1",
+        "url-set-query": "^1.0.0",
+        "xhr": "^2.0.4"
       }
     },
     "xhr-request-promise": {
@@ -7949,7 +8332,7 @@
       "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
       "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
       "requires": {
-        "xhr-request": "1.1.0"
+        "xhr-request": "^1.0.1"
       }
     },
     "xhr2": {
@@ -7988,19 +8371,19 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^4.2.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8013,9 +8396,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         }
       }
@@ -8025,7 +8408,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8040,8 +8423,8 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.0.1"
       }
     },
     "zeppelin-solidity": {
@@ -8049,8 +8432,8 @@
       "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.6.0.tgz",
       "integrity": "sha512-OYv0QeEy2h5Esiz7/8vMpywTPDiAS0LSTbca5q0+xEDDSwP/uy2fhAguP7heLDelorf9gMxLMLBrGbn/2xBEMQ==",
       "requires": {
-        "dotenv": "4.0.0",
-        "ethjs-abi": "0.2.1"
+        "dotenv": "^4.0.0",
+        "ethjs-abi": "^0.2.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint test",
     "testrpc": "./node_modules/.bin/testrpc",
     "coverage": "scripts/coverage.sh",
+    "soldoc": "scripts/soldoc.sh",
     "clean": "rimraf build",
     "buildfornpm": "npm run clean && truffle compile"
   },
@@ -41,18 +42,20 @@
   },
   "devDependencies": {
     "coveralls": "^2.13.1",
-    "ethereumjs-testrpc": "4.1.3",
-    "rimraf": "^2.6.2",
-    "solidity-coverage": "^0.2.4",
-    "truffle": "4.0.5",
-    "truffle-contract": "^3.0.3",
-    "web3-eth-abi": "^1.0.0-beta.30",
     "eslint": "^4.16.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-standard": "^3.0.1"
+    "eslint-plugin-standard": "^3.0.1",
+    "ethereumjs-testrpc": "4.1.3",
+    "rimraf": "^2.6.2",
+    "solidity-coverage": "^0.2.4",
+    "solmd": "^0.2.3",
+    "truffle": "4.0.5",
+    "truffle-contract": "^3.0.3",
+    "truffle-flattener": "^1.2.5",
+    "web3-eth-abi": "^1.0.0-beta.30"
   },
   "engines": {
     "node": ">=8.9.4"

--- a/scripts/soldoc.sh
+++ b/scripts/soldoc.sh
@@ -1,0 +1,14 @@
+mkdir docs .flattened
+# Preserve README
+mv docs/README.md docs/README.keep
+rm docs/*.md
+mv docs/README.keep docs/README.md
+for f in $(find contracts -name *.sol)
+  do if [ `basename $f` != "Migrations.sol" ]; then
+    file=`basename $f`
+    filename="${file%.*}"
+    node_modules/.bin/truffle-flattener "$f" > .flattened/"$file"
+    node_modules/.bin/solmd .flattened/"$file" --dest docs/"$filename".md
+  fi
+done
+rm -r .flattened


### PR DESCRIPTION
Adds an npm script `soldoc` that can be used to generate Markdown documentation from the contracts source codes. Also fixes return statements notation in solidity, because solc and solmd expect a JSON format with named outputs.