### PR TITLE
breaking: Renames url to dataUri in hotel

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The smart contracts in the [hotel folder](https://github.com/windingtree/wt-cont
 
 ## Requirements
 
-LTS Node 8.9.4 is required for running the tests.
+LTS Node 10.3.0 is required for running the tests.
 
 ## Install
 

--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -58,10 +58,10 @@ contract WTIndex is Ownable, Base_Interface {
   /**
    * @dev `registerHotel` Register new hotel in the index.
    * Emits `HotelRegistered` on success.
-   * @param  url Hotel's data pointer
+   * @param  dataUri Hotel's data pointer
    */
-  function registerHotel(string url) external {
-    Hotel newHotel = new Hotel(msg.sender, url);
+  function registerHotel(string dataUri) external {
+    Hotel newHotel = new Hotel(msg.sender, dataUri);
     hotelsIndex[newHotel] = hotels.length;
     hotels.push(newHotel);
     hotelsByManagerIndex[newHotel] = hotelsByManager[msg.sender].length;

--- a/contracts/WTIndex_Interface.sol
+++ b/contracts/WTIndex_Interface.sol
@@ -15,7 +15,7 @@ contract WTIndex_Interface is Base_Interface {
   mapping(address => uint) public hotelsByManagerIndex;
   address public LifToken;
 
-  function registerHotel(string url) external;
+  function registerHotel(string dataUri) external;
   function deleteHotel(address hotel) external;
   function callHotel(address hotel, bytes data) external;
   function getHotelsLength() constant public returns (uint);

--- a/contracts/hotel/Hotel.sol
+++ b/contracts/hotel/Hotel.sol
@@ -19,30 +19,30 @@ contract Hotel is Destructible, Base_Interface {
   // Arbitrary locator of the off-chain stored hotel data
   // This might be an HTTPS resource, IPFS hash, Swarm address...
   // This is intentionally generic.
-  string public url;
+  string public dataUri;
   // Number of block when the Hotel was created
   uint public created;
 
   /**
    * @dev Constructor.
    * @param _manager address of hotel owner
-   * @param _url pointer to hotel data
+   * @param _dataUri pointer to hotel data
    */
-  function Hotel(address _manager, string _url) public {
+  function Hotel(address _manager, string _dataUri) public {
     require(_manager != address(0));
-    require(bytes(_url).length != 0);
+    require(bytes(_dataUri).length != 0);
     manager = _manager;
-    url = _url;
+    dataUri = _dataUri;
     created = block.number;
   }
 
   /**
-   * @dev `editInfo` Allows manager to change hotel's url.
-   * @param  _url New url pointer of this hotel
+   * @dev `editInfo` Allows manager to change hotel's dataUri.
+   * @param  _dataUri New dataUri pointer of this hotel
    */
-  function editInfo(string _url) onlyOwner() public {
-    require(bytes(_url).length != 0);
-    url = _url;
+  function editInfo(string _dataUri) onlyOwner() public {
+    require(bytes(_dataUri).length != 0);
+    dataUri = _dataUri;
   }
 
 

--- a/contracts/hotel/Hotel_Interface.sol
+++ b/contracts/hotel/Hotel_Interface.sol
@@ -15,13 +15,13 @@ contract Hotel_Interface is Destructible, Base_Interface {
   // Arbitrary locator of the off-chain stored hotel data
   // This might be an HTTPS resource, IPFS hash, Swarm address...
   // This is intentionally generic.
-  string public url;
+  string public dataUri;
   // Number of block when the Hotel was created
   uint public created;
 
   /**
-   * @dev `editInfo` Allows manager to change hotel's url.
-   * @param  _url New url pointer of this hotel
+   * @dev `editInfo` Allows manager to change hotel's dataUri.
+   * @param  _dataUri New dataUri pointer of this hotel
    */
-  function editInfo(string _url) onlyOwner() public;
+  function editInfo(string _dataUri) onlyOwner() public;
 }

--- a/test/helpers/hotel.js
+++ b/test/helpers/hotel.js
@@ -32,12 +32,12 @@ async function createHotel (wtIndex, hotelAccount) {
  */
 async function getHotelInfo (wtHotel) {
   // Hotel Info
-  const url = await wtHotel.url();
+  const dataUri = await wtHotel.dataUri();
   const manager = await wtHotel.manager();
   const created = await wtHotel.created();
 
   return {
-    url: isZeroString(url) ? null : url,
+    dataUri: isZeroString(dataUri) ? null : dataUri,
     manager: isZeroAddress(manager) ? null : manager,
     created: isZeroUint(created) ? null : parseInt(created),
   };

--- a/test/wt-hotel.js
+++ b/test/wt-hotel.js
@@ -11,7 +11,7 @@ abiDecoder.addABI(WTHotelInterface._json.abi);
 abiDecoder.addABI(WTIndex._json.abi);
 
 contract('Hotel', (accounts) => {
-  const hotelUrl = 'bzz://something';
+  const hotelUri = 'bzz://something';
   const hotelAccount = accounts[2];
   const nonOwnerAccount = accounts[3];
   let hotelAddress = help.zeroAddress;
@@ -22,7 +22,7 @@ contract('Hotel', (accounts) => {
     // Create and register a hotel
     beforeEach(async () => {
       wtIndex = await WTIndex.new();
-      await wtIndex.registerHotel(hotelUrl, { from: hotelAccount });
+      await wtIndex.registerHotel(hotelUri, { from: hotelAccount });
       let address = await wtIndex.getHotelsByManager(hotelAccount);
       hotelAddress = address[0];
       wtHotel = WTHotel.at(address[0]);
@@ -30,7 +30,7 @@ contract('Hotel', (accounts) => {
 
     it('should be initialised with the correct data', async () => {
       const info = await help.getHotelInfo(wtHotel);
-      assert.equal(info.url, hotelUrl);
+      assert.equal(info.dataUri, hotelUri);
       // We need callback, because getBlockNumber for some reason cannot be called with await
       const blockNumber = await help.promisify(cb => web3.eth.getBlockNumber(cb));
       assert.isAtMost(info.created, blockNumber);
@@ -60,9 +60,9 @@ contract('Hotel', (accounts) => {
   });
 
   describe('editInfo', () => {
-    const newUrl = 'goo.gl/12345';
+    const newDataUri = 'goo.gl/12345';
 
-    it('should not update hotel to an empty url', async () => {
+    it('should not update hotel to an empty dataUri', async () => {
       try {
         const data = await wtHotel.contract.editInfo.getData('');
         await wtIndex.callHotel(hotelAddress, data, { from: hotelAccount });
@@ -72,16 +72,16 @@ contract('Hotel', (accounts) => {
       }
     });
 
-    it('should update hotel\'s url', async () => {
-      const data = wtHotel.contract.editInfo.getData(newUrl);
+    it('should update hotel\'s dataUri', async () => {
+      const data = wtHotel.contract.editInfo.getData(newDataUri);
       await wtIndex.callHotel(hotelAddress, data, { from: hotelAccount });
       const info = await help.getHotelInfo(wtHotel);
-      assert.equal(info.url, newUrl);
+      assert.equal(info.dataUri, newDataUri);
     });
 
     it('should throw if not executed by owner', async () => {
       try {
-        await wtHotel.editInfo(newUrl, { from: nonOwnerAccount });
+        await wtHotel.editInfo(newDataUri, { from: nonOwnerAccount });
         throw new Error('should not have been called');
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));

--- a/test/wt-index.js
+++ b/test/wt-index.js
@@ -49,7 +49,7 @@ contract('WTIndex', (accounts) => {
     describe('registerHotel', () => {
       const expectedIndexPos = 1; // Position of the first hotel
 
-      it('should not register hotel with empty url', async () => {
+      it('should not register hotel with empty dataUri', async () => {
         try {
           await index.registerHotel('', { from: hotelAccount });
           throw new Error('should not have been called');
@@ -61,13 +61,13 @@ contract('WTIndex', (accounts) => {
       it('should put hotel where we expect it to be', async () => {
         const indexNonce = await help.promisify(cb => web3.eth.getTransactionCount(index.address, cb));
         const hotelAddress = help.determineAddress(index.address, indexNonce);
-        await index.registerHotel('url', { from: hotelAccount });
+        await index.registerHotel('dataUri', { from: hotelAccount });
         let address = await index.getHotelsByManager(hotelAccount);
         assert.equal(hotelAddress, address[0]);
       });
 
       it('should add a hotel to the registry', async () => {
-        await index.registerHotel('url', { from: hotelAccount });
+        await index.registerHotel('dataUri', { from: hotelAccount });
         const length = await index.getHotelsLength();
 
         const allHotels = await help.jsArrayFromSolidityArray(
@@ -91,7 +91,7 @@ contract('WTIndex', (accounts) => {
         assert.equal(hotel, hotelsByManager);
 
         const hotelInstance = await WTHotel.at(hotel);
-        assert.equal(await hotelInstance.url(), 'url');
+        assert.equal(await hotelInstance.dataUri(), 'dataUri');
       });
     });
 
@@ -99,7 +99,7 @@ contract('WTIndex', (accounts) => {
       const expectedIndexPos = 0; // Position of the hotel in the managers array
 
       it('should remove a hotel', async () => {
-        await index.registerHotel('url', { from: hotelAccount });
+        await index.registerHotel('dataUri', { from: hotelAccount });
         const length = await index.getHotelsLength();
 
         let allHotels = await help.jsArrayFromSolidityArray(
@@ -167,20 +167,20 @@ contract('WTIndex', (accounts) => {
       let wtHotel, hotelAddress;
 
       beforeEach(async () => {
-        await index.registerHotel('url', { from: hotelAccount });
+        await index.registerHotel('dataUri', { from: hotelAccount });
         let address = await index.getHotelsByManager(hotelAccount);
         hotelAddress = address[0];
         wtHotel = WTHotel.at(address[0]);
       });
 
       it('should proceed when calling as an owner', async () => {
-        const data = wtHotel.contract.editInfo.getData('newUrl');
+        const data = wtHotel.contract.editInfo.getData('newDataUri');
         await index.callHotel(hotelAddress, data, { from: hotelAccount });
-        assert.equal('newUrl', await wtHotel.contract.url());
+        assert.equal('newDataUri', await wtHotel.contract.dataUri());
       });
 
       it('should throw if calling as a non-owner', async () => {
-        const data = wtHotel.contract.editInfo.getData('newUrl');
+        const data = wtHotel.contract.editInfo.getData('newUri');
         try {
           await index.callHotel(hotelAddress, data, { from: nonOwnerAccount });
           throw new Error('should not have been called');
@@ -190,7 +190,7 @@ contract('WTIndex', (accounts) => {
       });
 
       it('should throw if a hotel has zero address', async () => {
-        const data = wtHotel.contract.editInfo.getData('newUrl');
+        const data = wtHotel.contract.editInfo.getData('newUri');
         try {
           // Mocking address with existing contract
           await index.callHotel(help.zeroAddress, data, { from: hotelAccount });
@@ -201,7 +201,7 @@ contract('WTIndex', (accounts) => {
       });
 
       it('should throw if hotel does not exist', async () => {
-        const data = wtHotel.contract.editInfo.getData('newUrl');
+        const data = wtHotel.contract.editInfo.getData('newUri');
         try {
           // mocking address with existing account
           await index.callHotel(nonOwnerAccount, data, { from: hotelAccount });


### PR DESCRIPTION
This is done to make our data docs on SwaggerHub consistent with the actual code.

Also, `dataUri` is much more descriptive than the old url.