### PR TITLE
chore: Forces github to highlight solidity source code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
As per https://medium.com/@robertodev/solidity-and-github-42a3ca375618