### PR TITLE
Add networks migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ coverage
 coverage.json
 .flattened
 allFiredEvents
+
+# truffle build
+build
+
+# ETH keys
+keys.json

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,5 @@ coverage.json
 .flattened
 allFiredEvents
 
-# truffle build
-build
-
 # ETH keys
 keys.json

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ git clone https://github.com/windingtree/wt-contracts
 npm install
 ```
 
+## Deploy
+
+keys.json example:
+```
+{
+  "mnemonic": SEED_PHRASE,
+  "infura_apikey": API_KEY
+}
+```
+
+```sh
+npm run deploy-NETWORK
+```
+
 ## Test
 
 * To run all tests: `npm test`
@@ -30,8 +44,10 @@ npm install
 
 [Here](https://github.com/windingtree/wt-contracts/tree/master/docs)
 
+## Deployed Implementations
+
+[WTIndex - Ropsten](https://ropsten.etherscan.io/address/0x8a28895feec6cec757a0b8a8206125ca445f036f)
+
 ## License
 
 Winding Tree contracts are open source and distributed under the GPL v3 license.
-
-

--- a/README.md
+++ b/README.md
@@ -42,15 +42,11 @@ npm run deploy-NETWORK
 
 ## Flattener
 
-A flattener script is available by running `npm run flattener`, this will create flattened version of the contracts without imports in one single file for all contracts in the contracts folder.
+A flattener script is available by running `npm run flattener`, this will create flattened version of the contracts without imports in one single file for all contracts in the contracts folder. This is needed if you plan to use tools like [etherscan verifier](https://etherscan.io/verifyContract) or [securify.ch](https://securify.ch/).
 
 ## Documentation
 
 [Here](https://github.com/windingtree/wt-contracts/tree/master/docs)
-
-## Deployed Implementations
-
-[WTIndex - Ropsten](https://ropsten.etherscan.io/address/0x8a28895feec6cec757a0b8a8206125ca445f036f)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ npm run deploy-NETWORK
 
 * To generate coverage report: `npm run coverage`
 
+## Flattener
+
+A flattener script is available by running `npm run flattener`, this will create flattened version of the contracts without imports in one single file for all contracts in the contracts folder.
+
 ## Documentation
 
 [Here](https://github.com/windingtree/wt-contracts/tree/master/docs)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,2 +1,18 @@
-module.exports = function(deployer) {
+const WTIndex = artifacts.require('WTIndex');
+
+
+module.exports = function (deployer, network, accounts) {
+  console.log('Network:', network);
+  console.log('Accounts:', accounts);
+
+  const lifTokenAddress = (network == 'mainnent')
+    ? '0xeb9951021698b42e4399f9cbb6267aa35f82d59d'
+    : '0x5FDFBa355A30FB00ee12965cf3a1c24CA8DF77FB';
+
+  deployer.deploy(WTIndex).then(function (wtIndexContract) {
+    console.log('WTIndex address:', wtIndexContract.address);
+    wtIndexContract.setLifToken(lifTokenAddress).then(function (tx) {
+      console.log('LifToken set on tx:', tx.hash);
+    });
+  });
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -2,17 +2,19 @@ const WTIndex = artifacts.require('WTIndex');
 
 
 module.exports = function (deployer, network, accounts) {
-  console.log('Network:', network);
-  console.log('Accounts:', accounts);
+  if (network == 'mainnent' || network == 'ropsten') {
+    console.log('Network:', network);
+    console.log('Accounts:', accounts);
 
-  const lifTokenAddress = (network == 'mainnent')
-    ? '0xeb9951021698b42e4399f9cbb6267aa35f82d59d'
-    : '0x5FDFBa355A30FB00ee12965cf3a1c24CA8DF77FB';
+    const lifTokenAddress = (network == 'mainnent')
+      ? '0xeb9951021698b42e4399f9cbb6267aa35f82d59d'
+      : '0x5FDFBa355A30FB00ee12965cf3a1c24CA8DF77FB';
 
-  deployer.deploy(WTIndex).then(function (wtIndexContract) {
-    console.log('WTIndex address:', wtIndexContract.address);
-    wtIndexContract.setLifToken(lifTokenAddress).then(function (tx) {
-      console.log('LifToken set on tx:', tx.hash);
+    deployer.deploy(WTIndex).then(function (wtIndexContract) {
+      console.log('WTIndex address:', wtIndexContract.address);
+      wtIndexContract.setLifToken(lifTokenAddress).then(function (tx) {
+        console.log('LifToken set on tx:', tx.tx);
+      });
     });
-  });
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3136,6 +3136,16 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
         "ethereumjs-util": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+          "requires": {
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^5.0.0"
+          }
+        }
       }
     },
     "eth-tx-summary": {
@@ -3242,6 +3252,29 @@
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
       "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+    },
+    "ethereumjs-abi": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "requires": {
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^4.3.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+          "requires": {
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
+          }
+        }
+      }
     },
     "ethereumjs-account": {
       "version": "2.0.5",
@@ -4127,7 +4160,8 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -4136,7 +4170,8 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4239,7 +4274,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4249,6 +4285,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4268,11 +4305,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4289,6 +4328,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4361,7 +4401,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4371,6 +4412,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4476,6 +4518,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9666,8 +9709,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-          "dev": true
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         },
         "truffle-error": {
           "version": "0.0.3",
@@ -9681,11 +9723,16 @@
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "dev": true,
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+            }
           }
         }
       }
@@ -9870,8 +9917,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-          "dev": true
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         },
         "web3": {
           "version": "0.20.6",
@@ -9879,11 +9925,16 @@
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "dev": true,
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+            }
           }
         }
       }
@@ -9964,14 +10015,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -10579,8 +10622,19 @@
       "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.34"
+      },
+      "dependencies": {
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -11082,16 +11136,6 @@
         }
       }
     },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
-      }
-    },
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
@@ -11217,11 +11261,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "testrpc": "./node_modules/.bin/ganache-cli",
     "coverage": "SOLIDITY_COVERAGE=true npm run test",
     "soldoc": "scripts/soldoc.sh",
+    "flattener": "scripts/flattener.sh",
     "clean": "rimraf build",
     "buildfornpm": "npm run clean && truffle compile"
   },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "abi-decoder": "^1.1.0",
     "babel-polyfill": "^6.23.0",
     "chai": "^4.1.2",
+    "ethereumjs-abi": "^0.6.5",
     "ethereumjs-util": "^5.1.5",
     "moment": "^2.21.0",
     "openzeppelin-solidity": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "soldoc": "scripts/soldoc.sh",
     "flattener": "scripts/flattener.sh",
     "clean": "rimraf build",
-    "buildfornpm": "npm run clean && truffle compile"
+    "buildfornpm": "npm run clean && truffle compile",
+    "deploy-mainnet": "./node_modules/.bin/truffle migrate --network mainnet --reset",
+    "deploy-ropsten": "./node_modules/.bin/truffle migrate --network ropsten --reset"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/flattener.sh
+++ b/scripts/flattener.sh
@@ -1,0 +1,7 @@
+mkdir .flattened
+for f in $(find contracts -name *.sol)
+  do if [ `basename $f` != "Migrations.sol" ]; then
+    file=`basename $f`
+    node_modules/.bin/truffle-flattener "$f" > .flattened/"$file"
+  fi
+done

--- a/truffle.js
+++ b/truffle.js
@@ -16,7 +16,9 @@ module.exports = {
       port: 8555,
       gas: 0xfffffffffff,
       gasPrice: 0x01
-    }
+    },
+    mainnet: getInfuraConfig('mainnet', 1),
+    ropsten: getInfuraConfig('ropsten', 3)
   },
   solc: {
     optimizer: {
@@ -25,3 +27,21 @@ module.exports = {
     }
   }
 };
+
+function getInfuraConfig (networkName, networkId) {
+  var HDWalletProvider = require('truffle-hdwallet-provider')
+  var keys = {}
+  try {
+    keys = require('./keys.json')
+  } catch (err) {
+    console.log('could not find ./keys.json')
+  }
+
+  return {
+    network_id: networkId,
+    provider: () => {
+      return new HDWalletProvider(keys.mnemonic, `https://${networkName}.infura.io/` + keys.infura_apikey)
+    },
+    gas: 4600000
+  }
+}


### PR DESCRIPTION
- Adds flattener script to easily verify source codes in etherscan once contracts are deployed.
- Adds migration scripts to deploy WTIndex in mainnet or ropsten using a seed phrase for wallet generation and infura to communicate with networks.
- The deployed contract with verified source code on etherscan is on the readme.

fix #191 