### PR TITLE
Remove Destructible import and use selfdestruct to hotel manager

### DIFF
--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -81,7 +81,7 @@ contract WTIndex is AbstractWTIndex {
     // Ensure that the caller is the hotel's rightful owner
     // There may actually be a hotel on index zero, that's why we use a double check
     require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
-    Hotel(hotel).destroy(msg.sender);
+    Hotel(hotel).destroy();
     uint index = hotelsByManagerIndex[hotel];
     uint allIndex = hotelsIndex[hotel];
     delete hotels[allIndex];

--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -81,7 +81,7 @@ contract WTIndex is AbstractWTIndex {
     // Ensure that the caller is the hotel's rightful owner
     // There may actually be a hotel on index zero, that's why we use a double check
     require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
-    Hotel(hotel).destroy();
+    Hotel(hotel).destroy(msg.sender);
     uint index = hotelsByManagerIndex[hotel];
     uint allIndex = hotelsIndex[hotel];
     delete hotels[allIndex];

--- a/contracts/hotel/AbstractHotel.sol
+++ b/contracts/hotel/AbstractHotel.sol
@@ -1,14 +1,14 @@
 pragma solidity ^0.4.24;
 
 import "../AbstractBaseContract.sol";
-import "openzeppelin-solidity/contracts/lifecycle/Destructible.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 /**
  * @title AbstractHotel
  * @dev Interface of Hotel contract, inherits
- * from OpenZeppelin's `Destructible` and WT's 'AbstractBaseContract'.
+ * from OpenZeppelin's `Ownable` and WT's 'AbstractBaseContract'.
  */
-contract AbstractHotel is Destructible, AbstractBaseContract {
+contract AbstractHotel is Ownable, AbstractBaseContract {
 
   // Who owns this Hotel and can manage it.
   address public manager;

--- a/contracts/hotel/Hotel.sol
+++ b/contracts/hotel/Hotel.sol
@@ -41,8 +41,8 @@ contract Hotel is AbstractHotel {
   /**
    * @dev `destroy` allows the owner to delete the Hotel
    */
-  function destroy(address _manager) onlyOwner public {
-    selfdestruct(_manager);
+  function destroy() onlyOwner public {
+    selfdestruct(manager);
   }
 
 }

--- a/contracts/hotel/Hotel.sol
+++ b/contracts/hotel/Hotel.sol
@@ -5,7 +5,7 @@ import "./AbstractHotel.sol";
 /**
  * @title Hotel, contract for a Hotel registered in the WT network
  * @dev A contract that represents a hotel in the WT network. Inherits
- * from OpenZeppelin's `Destructible` and WT's 'AbstractBaseContract'.
+ * from OpenZeppelin's `Ownable` and WT's 'AbstractBaseContract'.
  */
 contract Hotel is AbstractHotel {
 
@@ -41,8 +41,8 @@ contract Hotel is AbstractHotel {
   /**
    * @dev `destroy` allows the owner to delete the Hotel
    */
-  function destroy() onlyOwner public {
-    super.destroyAndSend(tx.origin);
+  function destroy(address _manager) onlyOwner public {
+    selfdestruct(_manager);
   }
 
 }


### PR DESCRIPTION
As @JirkaChadima mention in #196 it is not safe to use tx.origin, this PR removes the use of it and replace it for the address received as argument. It also replace the destroyAndSend function from Destructible for the global `selfdestruct` method.

We discuss removing the destroy method, I know that there is no way for it to have wei but I think it is useful to implement a destroy method if the contract wont be used anymore. We dont want to have dummy contracts on the network. This is why I just fixed the use of tx.origin.