### PR TITLE
feat: Transferring hotels between owners

### DIFF
--- a/contracts/AbstractWTIndex.sol
+++ b/contracts/AbstractWTIndex.sol
@@ -18,6 +18,7 @@ contract AbstractWTIndex is Ownable, AbstractBaseContract {
   function registerHotel(string dataUri) external;
   function deleteHotel(address hotel) external;
   function callHotel(address hotel, bytes data) external;
+  function transferHotel(address hotel, address newManager) external;
   function getHotelsLength() view public returns (uint);
   function getHotels() view public returns (address[]);
   function getHotelsByManager(address manager) view public returns (address[]);
@@ -25,4 +26,5 @@ contract AbstractWTIndex is Ownable, AbstractBaseContract {
   event HotelRegistered(address hotel, uint managerIndex, uint allIndex);
   event HotelDeleted(address hotel, uint managerIndex, uint allIndex);
   event HotelCalled(address hotel);
+  event HotelTransferred(address hotel, address previousManager, address newManager);
 }

--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -60,7 +60,7 @@ contract WTIndex is AbstractWTIndex {
    * @param  dataUri Hotel's data pointer
    */
   function registerHotel(string dataUri) external {
-    Hotel newHotel = new Hotel(msg.sender, dataUri);
+    Hotel newHotel = new Hotel(msg.sender, dataUri, this);
     hotelsIndex[newHotel] = hotels.length;
     hotels.push(newHotel);
     hotelsByManagerIndex[newHotel] = hotelsByManager[msg.sender].length;
@@ -81,7 +81,12 @@ contract WTIndex is AbstractWTIndex {
     // Ensure that the caller is the hotel's rightful owner
     // There may actually be a hotel on index zero, that's why we use a double check
     require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
-    Hotel(hotel).destroy();
+
+    Hotel hotelInstance = Hotel(hotel);
+    // Ensure we are calling only our own hotels
+    require(hotelInstance.index() == address(this));
+    hotelInstance.destroy();
+    
     uint index = hotelsByManagerIndex[hotel];
     uint allIndex = hotelsIndex[hotel];
     delete hotels[allIndex];
@@ -105,7 +110,10 @@ contract WTIndex is AbstractWTIndex {
     require(hotelsIndex[hotel] != uint(0));
     // Ensure that the caller is the hotel's rightful owner
     require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
-		require(hotel.call(data));
+    Hotel hotelInstance = Hotel(hotel);
+    // Ensure we are calling only our own hotels
+    require(hotelInstance.index() == address(this));
+    require(hotel.call(data));
     emit HotelCalled(hotel);
 	}
 

--- a/contracts/hotel/AbstractHotel.sol
+++ b/contracts/hotel/AbstractHotel.sol
@@ -1,14 +1,16 @@
 pragma solidity ^0.4.24;
 
 import "../AbstractBaseContract.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 /**
  * @title AbstractHotel
- * @dev Interface of Hotel contract, inherits
- * from OpenZeppelin's `Ownable` and WT's 'AbstractBaseContract'.
+ * @dev Interface of Hotel contract, inherits from
+ * WT's 'AbstractBaseContract'.
  */
-contract AbstractHotel is Ownable, AbstractBaseContract {
+contract AbstractHotel is AbstractBaseContract {
+
+  // Who owns this Hotel and can manage it.
+  address public manager;
 
   // Arbitrary locator of the off-chain stored hotel data
   // This might be an HTTPS resource, IPFS hash, Swarm address...
@@ -31,6 +33,8 @@ contract AbstractHotel is Ownable, AbstractBaseContract {
 
 
   function _editInfoImpl(string _dataUri) internal;
+  function _destroyImpl() internal;
+  function _changeManagerImpl(address _newManager) internal;
 
   /**
    * @dev `editInfo` Allows owner to change hotel's dataUri.
@@ -38,5 +42,20 @@ contract AbstractHotel is Ownable, AbstractBaseContract {
    */
   function editInfo(string _dataUri) onlyFromIndex public {
     _editInfoImpl(_dataUri);
+  }
+
+  /**
+   * @dev `destroy` allows the owner to delete the Hotel
+   */
+  function destroy() onlyFromIndex public {
+    _destroyImpl();
+  }
+
+  /**
+   * @dev Allows owner to change hotel manager.
+   * @param _newManager New manager's address
+   */
+  function changeManager(address _newManager) onlyFromIndex public {
+    _changeManagerImpl(_newManager);
   }
 }

--- a/contracts/hotel/AbstractHotel.sol
+++ b/contracts/hotel/AbstractHotel.sol
@@ -10,8 +10,6 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
  */
 contract AbstractHotel is Ownable, AbstractBaseContract {
 
-  // Who owns this Hotel and can manage it.
-  address public manager;
   // Arbitrary locator of the off-chain stored hotel data
   // This might be an HTTPS resource, IPFS hash, Swarm address...
   // This is intentionally generic.
@@ -19,14 +17,26 @@ contract AbstractHotel is Ownable, AbstractBaseContract {
   // Number of block when the Hotel was created
   uint public created;
 
+  // WTIndex address
+  address public index;
+
+  /**
+   * Allows calling such methods only when msg.sender is equal
+   * to previously set index propert.y
+   */
+  modifier onlyFromIndex() {
+    require(msg.sender == index);
+    _;
+  }
+
 
   function _editInfoImpl(string _dataUri) internal;
 
   /**
-   * @dev `editInfo` Allows manager to change hotel's dataUri.
+   * @dev `editInfo` Allows owner to change hotel's dataUri.
    * @param  _dataUri New dataUri pointer of this hotel
    */
-  function editInfo(string _dataUri) onlyOwner public {
+  function editInfo(string _dataUri) onlyFromIndex public {
     _editInfoImpl(_dataUri);
   }
 }

--- a/contracts/hotel/Hotel.sol
+++ b/contracts/hotel/Hotel.sol
@@ -11,24 +11,18 @@ contract Hotel is AbstractHotel {
 
   bytes32 public contractType = bytes32("hotel");
 
-  // Who owns this Hotel and can manage it.
-  address public manager;
-  // Arbitrary locator of the off-chain stored hotel data
-  // This might be an HTTPS resource, IPFS hash, Swarm address...
-  // This is intentionally generic.
-  string public dataUri;
-  // Number of block when the Hotel was created
-  uint public created;
-
   /**
    * @dev Constructor.
    * @param _manager address of hotel owner
    * @param _dataUri pointer to hotel data
+   * @param _index originating WTIndex address
    */
-  constructor(address _manager, string _dataUri) public {
+  constructor(address _manager, string _dataUri, address _index) public {
     require(_manager != address(0));
+    require(_index != address(0));
     require(bytes(_dataUri).length != 0);
-    manager = _manager;
+    owner = _manager;
+    index = _index;
     dataUri = _dataUri;
     created = block.number;
   }
@@ -41,8 +35,8 @@ contract Hotel is AbstractHotel {
   /**
    * @dev `destroy` allows the owner to delete the Hotel
    */
-  function destroy() onlyOwner public {
-    selfdestruct(manager);
+  function destroy() onlyFromIndex public {
+    selfdestruct(owner);
   }
 
 }

--- a/contracts/hotel/Hotel.sol
+++ b/contracts/hotel/Hotel.sol
@@ -5,7 +5,7 @@ import "./AbstractHotel.sol";
 /**
  * @title Hotel, contract for a Hotel registered in the WT network
  * @dev A contract that represents a hotel in the WT network. Inherits
- * from OpenZeppelin's `Ownable` and WT's 'AbstractBaseContract'.
+ * from WT's 'AbstractHotel'.
  */
 contract Hotel is AbstractHotel {
 
@@ -21,7 +21,7 @@ contract Hotel is AbstractHotel {
     require(_manager != address(0));
     require(_index != address(0));
     require(bytes(_dataUri).length != 0);
-    owner = _manager;
+    manager = _manager;
     index = _index;
     dataUri = _dataUri;
     created = block.number;
@@ -32,11 +32,13 @@ contract Hotel is AbstractHotel {
     dataUri = _dataUri;
   }
 
-  /**
-   * @dev `destroy` allows the owner to delete the Hotel
-   */
-  function destroy() onlyFromIndex public {
-    selfdestruct(owner);
+  function _destroyImpl() internal {
+    selfdestruct(manager);
+  }
+
+  function _changeManagerImpl(address _newManager) internal {
+    require(_newManager != address(0));
+    manager = _newManager;
   }
 
 }

--- a/docs/AbstractHotel.md
+++ b/docs/AbstractHotel.md
@@ -1,17 +1,23 @@
 * [AbstractHotel](#abstracthotel)
+  * [index](#function-index)
   * [created](#function-created)
   * [manager](#function-manager)
   * [version](#function-version)
-  * [renounceOwnership](#function-renounceownership)
+  * [destroy](#function-destroy)
   * [dataUri](#function-datauri)
-  * [owner](#function-owner)
   * [editInfo](#function-editinfo)
+  * [changeManager](#function-changemanager)
   * [contractType](#function-contracttype)
-  * [transferOwnership](#function-transferownership)
-  * [OwnershipRenounced](#event-ownershiprenounced)
-  * [OwnershipTransferred](#event-ownershiptransferred)
 
 # AbstractHotel
+
+
+## *function* index
+
+AbstractHotel.index() `view` `2986c0e5`
+
+
+
 
 
 ## *function* created
@@ -38,13 +44,11 @@ AbstractHotel.version() `view` `54fd4d50`
 
 
 
-## *function* renounceOwnership
+## *function* destroy
 
-AbstractHotel.renounceOwnership() `nonpayable` `715018a6`
+AbstractHotel.destroy() `nonpayable` `83197ef0`
 
-**Renouncing to ownership will leave the contract without an owner. It will not be possible to call the functions with the `onlyOwner` modifier anymore.**
-
-> Allows the current owner to relinquish control of the contract.
+> `destroy` allows the owner to delete the Hotel
 
 
 
@@ -57,19 +61,11 @@ AbstractHotel.dataUri() `view` `8a9b29eb`
 
 
 
-## *function* owner
-
-AbstractHotel.owner() `view` `8da5cb5b`
-
-
-
-
-
 ## *function* editInfo
 
 AbstractHotel.editInfo(_dataUri) `nonpayable` `9d9b5342`
 
-> `editInfo` Allows manager to change hotel's dataUri.
+> `editInfo` Allows owner to change hotel's dataUri.
 
 Inputs
 
@@ -78,46 +74,25 @@ Inputs
 | *string* | _dataUri | New dataUri pointer of this hotel |
 
 
+## *function* changeManager
+
+AbstractHotel.changeManager(_newManager) `nonpayable` `a3fbbaae`
+
+> Allows owner to change hotel manager.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _newManager | New manager's address |
+
+
 ## *function* contractType
 
 AbstractHotel.contractType() `view` `cb2ef6f7`
 
 
 
-
-
-## *function* transferOwnership
-
-AbstractHotel.transferOwnership(_newOwner) `nonpayable` `f2fde38b`
-
-> Allows the current owner to transfer control of the contract to a newOwner.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | _newOwner | The address to transfer ownership to. |
-
-## *event* OwnershipRenounced
-
-AbstractHotel.OwnershipRenounced(previousOwner) `f8df3114`
-
-Arguments
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | previousOwner | indexed |
-
-## *event* OwnershipTransferred
-
-AbstractHotel.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
-
-Arguments
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | previousOwner | indexed |
-| *address* | newOwner | indexed |
 
 
 ---

--- a/docs/AbstractWTIndex.md
+++ b/docs/AbstractWTIndex.md
@@ -2,6 +2,7 @@
   * [getHotels](#function-gethotels)
   * [callHotel](#function-callhotel)
   * [hotelsByManagerIndex](#function-hotelsbymanagerindex)
+  * [transferHotel](#function-transferhotel)
   * [version](#function-version)
   * [LifToken](#function-liftoken)
   * [renounceOwnership](#function-renounceownership)
@@ -18,6 +19,7 @@
   * [HotelRegistered](#event-hotelregistered)
   * [HotelDeleted](#event-hoteldeleted)
   * [HotelCalled](#event-hotelcalled)
+  * [HotelTransferred](#event-hoteltransferred)
   * [OwnershipRenounced](#event-ownershiprenounced)
   * [OwnershipTransferred](#event-ownershiptransferred)
 
@@ -55,6 +57,19 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* |  | undefined |
+
+
+## *function* transferHotel
+
+AbstractWTIndex.transferHotel(hotel, newManager) `nonpayable` `292d64e0`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | hotel | undefined |
+| *address* | newManager | undefined |
 
 
 ## *function* version
@@ -226,6 +241,18 @@ Arguments
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | hotel | not indexed |
+
+## *event* HotelTransferred
+
+AbstractWTIndex.HotelTransferred(hotel, previousManager, newManager) `04dd8111`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | hotel | not indexed |
+| *address* | previousManager | not indexed |
+| *address* | newManager | not indexed |
 
 ## *event* OwnershipRenounced
 

--- a/docs/Hotel.md
+++ b/docs/Hotel.md
@@ -1,18 +1,23 @@
 * [Hotel](#hotel)
+  * [index](#function-index)
   * [created](#function-created)
   * [manager](#function-manager)
   * [version](#function-version)
-  * [renounceOwnership](#function-renounceownership)
   * [destroy](#function-destroy)
   * [dataUri](#function-datauri)
-  * [owner](#function-owner)
   * [editInfo](#function-editinfo)
+  * [changeManager](#function-changemanager)
   * [contractType](#function-contracttype)
-  * [transferOwnership](#function-transferownership)
-  * [OwnershipRenounced](#event-ownershiprenounced)
-  * [OwnershipTransferred](#event-ownershiptransferred)
 
 # Hotel
+
+
+## *function* index
+
+Hotel.index() `view` `2986c0e5`
+
+
+
 
 
 ## *function* created
@@ -39,17 +44,6 @@ Hotel.version() `view` `54fd4d50`
 
 
 
-## *function* renounceOwnership
-
-Hotel.renounceOwnership() `nonpayable` `715018a6`
-
-**Renouncing to ownership will leave the contract without an owner. It will not be possible to call the functions with the `onlyOwner` modifier anymore.**
-
-> Allows the current owner to relinquish control of the contract.
-
-
-
-
 ## *function* destroy
 
 Hotel.destroy() `nonpayable` `83197ef0`
@@ -67,25 +61,30 @@ Hotel.dataUri() `view` `8a9b29eb`
 
 
 
-## *function* owner
-
-Hotel.owner() `view` `8da5cb5b`
-
-
-
-
-
 ## *function* editInfo
 
 Hotel.editInfo(_dataUri) `nonpayable` `9d9b5342`
 
-> `editInfo` Allows manager to change hotel's dataUri.
+> `editInfo` Allows owner to change hotel's dataUri.
 
 Inputs
 
 | **type** | **name** | **description** |
 |-|-|-|
 | *string* | _dataUri | New dataUri pointer of this hotel |
+
+
+## *function* changeManager
+
+Hotel.changeManager(_newManager) `nonpayable` `a3fbbaae`
+
+> Allows owner to change hotel manager.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _newManager | New manager's address |
 
 
 ## *function* contractType
@@ -95,40 +94,6 @@ Hotel.contractType() `view` `cb2ef6f7`
 
 
 
-
-## *function* transferOwnership
-
-Hotel.transferOwnership(_newOwner) `nonpayable` `f2fde38b`
-
-> Allows the current owner to transfer control of the contract to a newOwner.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | _newOwner | The address to transfer ownership to. |
-
-
-## *event* OwnershipRenounced
-
-Hotel.OwnershipRenounced(previousOwner) `f8df3114`
-
-Arguments
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | previousOwner | indexed |
-
-## *event* OwnershipTransferred
-
-Hotel.OwnershipTransferred(previousOwner, newOwner) `8be0079c`
-
-Arguments
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | previousOwner | indexed |
-| *address* | newOwner | indexed |
 
 
 ---

--- a/docs/WTIndex.md
+++ b/docs/WTIndex.md
@@ -2,6 +2,7 @@
   * [getHotels](#function-gethotels)
   * [callHotel](#function-callhotel)
   * [hotelsByManagerIndex](#function-hotelsbymanagerindex)
+  * [transferHotel](#function-transferhotel)
   * [version](#function-version)
   * [LifToken](#function-liftoken)
   * [renounceOwnership](#function-renounceownership)
@@ -19,6 +20,7 @@
   * [HotelRegistered](#event-hotelregistered)
   * [HotelDeleted](#event-hoteldeleted)
   * [HotelCalled](#event-hotelcalled)
+  * [HotelTransferred](#event-hoteltransferred)
   * [OwnershipRenounced](#event-ownershiprenounced)
   * [OwnershipTransferred](#event-ownershiptransferred)
 
@@ -63,6 +65,19 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* |  | undefined |
+
+
+## *function* transferHotel
+
+WTIndex.transferHotel(hotel, newManager) `nonpayable` `292d64e0`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | hotel | undefined |
+| *address* | newManager | undefined |
 
 
 ## *function* version
@@ -262,6 +277,18 @@ Arguments
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | hotel | not indexed |
+
+## *event* HotelTransferred
+
+WTIndex.HotelTransferred(hotel, previousManager, newManager) `04dd8111`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | hotel | not indexed |
+| *address* | previousManager | not indexed |
+| *address* | newManager | not indexed |
 
 ## *event* OwnershipRenounced
 

--- a/test/helpers/hotel.js
+++ b/test/helpers/hotel.js
@@ -35,10 +35,12 @@ async function getHotelInfo (wtHotel) {
   const dataUri = await wtHotel.dataUri();
   const owner = await wtHotel.owner();
   const created = await wtHotel.created();
+  const index = await wtHotel.index();
 
   return {
     dataUri: isZeroString(dataUri) ? null : dataUri,
     owner: isZeroAddress(owner) ? null : owner,
+    index: isZeroAddress(index) ? null : index,
     created: isZeroUint(created) ? null : parseInt(created),
   };
 }

--- a/test/helpers/hotel.js
+++ b/test/helpers/hotel.js
@@ -33,13 +33,13 @@ async function createHotel (wtIndex, hotelAccount) {
 async function getHotelInfo (wtHotel) {
   // Hotel Info
   const dataUri = await wtHotel.dataUri();
-  const owner = await wtHotel.owner();
+  const manager = await wtHotel.manager();
   const created = await wtHotel.created();
   const index = await wtHotel.index();
 
   return {
     dataUri: isZeroString(dataUri) ? null : dataUri,
-    owner: isZeroAddress(owner) ? null : owner,
+    manager: isZeroAddress(manager) ? null : manager,
     index: isZeroAddress(index) ? null : index,
     created: isZeroUint(created) ? null : parseInt(created),
   };

--- a/test/helpers/hotel.js
+++ b/test/helpers/hotel.js
@@ -33,12 +33,12 @@ async function createHotel (wtIndex, hotelAccount) {
 async function getHotelInfo (wtHotel) {
   // Hotel Info
   const dataUri = await wtHotel.dataUri();
-  const manager = await wtHotel.manager();
+  const owner = await wtHotel.owner();
   const created = await wtHotel.created();
 
   return {
     dataUri: isZeroString(dataUri) ? null : dataUri,
-    manager: isZeroAddress(manager) ? null : manager,
+    owner: isZeroAddress(owner) ? null : owner,
     created: isZeroUint(created) ? null : parseInt(created),
   };
 }

--- a/test/wt-hotel.js
+++ b/test/wt-hotel.js
@@ -4,10 +4,10 @@ const abiDecoder = require('abi-decoder');
 
 const WTIndex = artifacts.require('WTIndex.sol');
 const WTHotel = artifacts.require('Hotel.sol');
-const WTHotelInterface = artifacts.require('AbstractHotel.sol');
+const AbstractWTHotel = artifacts.require('AbstractHotel.sol');
 const AbstractBaseContract = artifacts.require('AbstractBaseContract.sol');
 
-abiDecoder.addABI(WTHotelInterface._json.abi);
+abiDecoder.addABI(AbstractWTHotel._json.abi);
 abiDecoder.addABI(WTIndex._json.abi);
 
 contract('Hotel', (accounts) => {
@@ -18,27 +18,29 @@ contract('Hotel', (accounts) => {
   let wtIndex;
   let wtHotel;
 
-  describe('Constructor', () => {
-    // Create and register a hotel
-    beforeEach(async () => {
-      wtIndex = await WTIndex.new();
-      await wtIndex.registerHotel(hotelUri, { from: hotelAccount });
-      let address = await wtIndex.getHotelsByManager(hotelAccount);
-      hotelAddress = address[0];
-      wtHotel = WTHotel.at(address[0]);
-    });
+  // Create and register a hotel
+  beforeEach(async () => {
+    wtIndex = await WTIndex.new();
+    await wtIndex.registerHotel(hotelUri, { from: hotelAccount });
+    let address = await wtIndex.getHotelsByManager(hotelAccount);
+    hotelAddress = address[0];
+    wtHotel = WTHotel.at(address[0]);
+  });
 
+  describe('Constructor', () => {
     it('should be initialised with the correct data', async () => {
       const info = await help.getHotelInfo(wtHotel);
-      assert.equal(info.dataUri, hotelUri);
       // We need callback, because getBlockNumber for some reason cannot be called with await
       const blockNumber = await help.promisify(cb => web3.eth.getBlockNumber(cb));
       assert.isAtMost(info.created, blockNumber);
       assert.equal(info.owner, hotelAccount);
+      assert.equal(info.dataUri, hotelUri);
+      assert.equal(info.index, wtIndex.contract.address);
+      // There's an empty address as an initial value, that's why we compare
       assert.equal((await wtIndex.getHotels()).length, 2);
     });
 
-    it('should properly setup ownership', async () => {
+    it('should properly setup owner and index references', async () => {
       assert.equal(wtIndex.contract.address, await wtHotel.index());
       assert.equal(hotelAccount, await wtHotel.owner());
     });
@@ -57,19 +59,19 @@ contract('Hotel', (accounts) => {
         assert(help.isInvalidOpcodeEx(e));
       }
     });
+
+    it('should not be created with zero address for an index', async () => {
+      try {
+        await WTHotel.new(hotelAccount, 'goo.gl', help.zeroAddress);
+        throw new Error('should not have been called');
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
   });
 
   describe('editInfo', () => {
     const newDataUri = 'goo.gl/12345';
-
-    // Create and register a hotel
-    beforeEach(async () => {
-      wtIndex = await WTIndex.new();
-      await wtIndex.registerHotel(hotelUri, { from: hotelAccount });
-      let address = await wtIndex.getHotelsByManager(hotelAccount);
-      hotelAddress = address[0];
-      wtHotel = WTHotel.at(address[0]);
-    });
 
     it('should not update hotel to an empty dataUri', async () => {
       try {
@@ -88,9 +90,19 @@ contract('Hotel', (accounts) => {
       assert.equal(info.dataUri, newDataUri);
     });
 
-    it('should throw if not executed by owner', async () => {
+    it('should throw if not executed by hotel owner', async () => {
       try {
-        await wtHotel.editInfo(newDataUri, { from: nonOwnerAccount });
+        const data = wtHotel.contract.editInfo.getData(newDataUri);
+        await wtIndex.callHotel(hotelAddress, data, { from: nonOwnerAccount });
+        throw new Error('should not have been called');
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+
+    it('should throw if not executed from index address', async () => {
+      try {
+        await wtHotel.contract.editInfo(newDataUri, { from: nonOwnerAccount });
         throw new Error('should not have been called');
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));


### PR DESCRIPTION
Closes #199 

Introduces changes as suggested by @AugustoL in https://github.com/windingtree/wt-contracts/issues/199#issuecomment-406990508

- Removes hotel.manager property altogether and benefits from `Ownable`s owner property
- I did not rename all of the mapping properties in WTIndex as I think *manager* is more appropriate name for the actual hotel *owner*. We can add an alias method to hotel to make this more backwards compatible.

There is still a pretty huge problem though - If we call `transferOwnership` via `callHotel`, the hotel record will not be moved in `WTIndex`'s `hotelsByManager` mapping. I'm not sure what's the right approach to that, the only thing I can come up with is explicitly providing `transfer` method on `WTIndex` level. But that would probably require us to also disable directly calling `Ownable`s methods on Hotels.