### PR TITLE
Introduces solidity linter

### DIFF
--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,1 @@
+contracts/Migrations.sol

--- a/contracts/AbstractBaseContract.sol
+++ b/contracts/AbstractBaseContract.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
+
 
 /**
  * @title AbstractBaseContract
@@ -8,12 +9,11 @@ pragma solidity ^0.4.24;
  */
 contract AbstractBaseContract {
 
-  // The hex-encoded version, follows the semantic standard MAJOR.MINOR.PATCH-EXTENSION
-  // It should always match the version in package.json.
-  bytes32 public version = bytes32("0.2.4");
+    // The hex-encoded version, follows the semantic standard MAJOR.MINOR.PATCH-EXTENSION
+    // It should always match the version in package.json.
+    bytes32 public version = bytes32("0.2.4");
 
-  // The hex-encoded type of the contract, in all lowercase letters without any spaces.
-  // It has to be defined in each contract that uses this interface.
-  bytes32 public contractType;
-
+    // The hex-encoded type of the contract, in all lowercase letters without any spaces.
+    // It has to be defined in each contract that uses this interface.
+    bytes32 public contractType;
 }

--- a/contracts/AbstractWTIndex.sol
+++ b/contracts/AbstractWTIndex.sol
@@ -1,7 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 
 import "./AbstractBaseContract.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 
 /**
  * @title AbstractWTIndex
@@ -9,22 +10,23 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
  * from WT's 'AbstractBaseContract'.
  */
 contract AbstractWTIndex is Ownable, AbstractBaseContract {
-  address[] public hotels;
-  mapping(address => uint) public hotelsIndex;
-  mapping(address => address[]) public hotelsByManager;
-  mapping(address => uint) public hotelsByManagerIndex;
-  address public LifToken;
+    address[] public hotels;
+    mapping(address => uint) public hotelsIndex;
+    mapping(address => address[]) public hotelsByManager;
+    mapping(address => uint) public hotelsByManagerIndex;
+    // solhint-disable-next-line var-name-mixedcase
+    address public LifToken;
 
-  function registerHotel(string dataUri) external;
-  function deleteHotel(address hotel) external;
-  function callHotel(address hotel, bytes data) external;
-  function transferHotel(address hotel, address newManager) external;
-  function getHotelsLength() view public returns (uint);
-  function getHotels() view public returns (address[]);
-  function getHotelsByManager(address manager) view public returns (address[]);
+    function registerHotel(string dataUri) external;
+    function deleteHotel(address hotel) external;
+    function callHotel(address hotel, bytes data) external;
+    function transferHotel(address hotel, address newManager) external;
+    function getHotelsLength() public view returns (uint);
+    function getHotels() public view returns (address[]);
+    function getHotelsByManager(address manager) public view returns (address[]);
 
-  event HotelRegistered(address hotel, uint managerIndex, uint allIndex);
-  event HotelDeleted(address hotel, uint managerIndex, uint allIndex);
-  event HotelCalled(address hotel);
-  event HotelTransferred(address hotel, address previousManager, address newManager);
+    event HotelRegistered(address hotel, uint managerIndex, uint allIndex);
+    event HotelDeleted(address hotel, uint managerIndex, uint allIndex);
+    event HotelCalled(address hotel);
+    event HotelTransferred(address hotel, address previousManager, address newManager);
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 
 contract Migrations {
   address public owner;

--- a/contracts/WTIndex.sol
+++ b/contracts/WTIndex.sol
@@ -1,7 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 
 import "./AbstractWTIndex.sol";
 import "./hotel/Hotel.sol";
+
 
 /**
  * @title WTIndex, registry of all hotels registered on WT
@@ -10,167 +11,175 @@ import "./hotel/Hotel.sol";
  */
 contract WTIndex is AbstractWTIndex {
 
-  bytes32 public contractType = bytes32("wtindex");
+    bytes32 public contractType = bytes32("wtindex");
 
-  // Array of addresses of `Hotel` contracts
-  address[] public hotels;
-  // Mapping of hotels position in the general hotel index
-  mapping(address => uint) public hotelsIndex;
+    // Array of addresses of `Hotel` contracts
+    address[] public hotels;
 
-  // Mapping of the hotels indexed by manager's address
-  mapping(address => address[]) public hotelsByManager;
-  // Mapping of hotels position in the manager's indexed hotel index
-  mapping(address => uint) public hotelsByManagerIndex;
+    // Mapping of hotels position in the general hotel index
+    mapping(address => uint) public hotelsIndex;
 
-  // Address of the LifToken contract
-  address public LifToken;
+    // Mapping of the hotels indexed by manager's address
+    mapping(address => address[]) public hotelsByManager;
+    // Mapping of hotels position in the manager's indexed hotel index
+    mapping(address => uint) public hotelsByManagerIndex;
 
-  /**
-   * @dev Event triggered every time hotel is registered
-   */
-  event HotelRegistered(address hotel, uint managerIndex, uint allIndex);
-  /**
-   * @dev Event triggered every time hotel is deleted
-   */
-  event HotelDeleted(address hotel, uint managerIndex, uint allIndex);
-  /**
-   * @dev Event triggered every time hotel is called
-   */
-  event HotelCalled(address hotel);
+    // Address of the LifToken contract
+    // solhint-disable-next-line var-name-mixedcase
+    address public LifToken;
 
-  /**
-   * @dev Event triggered every time a hotel changes a manager.
-   */
-  event HotelTransferred(address hotel, address previousManager, address newManager);
+    /**
+     * @dev Event triggered every time hotel is registered
+     */
+    event HotelRegistered(address hotel, uint managerIndex, uint allIndex);
+    /**
+     * @dev Event triggered every time hotel is deleted
+     */
+    event HotelDeleted(address hotel, uint managerIndex, uint allIndex);
+    /**
+     * @dev Event triggered every time hotel is called
+     */
+    event HotelCalled(address hotel);
 
-  /**
-   * @dev Constructor. Creates the `WTIndex` contract
-   */
-	constructor() public {
-		hotels.length ++;
-	}
+    /**
+     * @dev Event triggered every time a hotel changes a manager.
+     */
+    event HotelTransferred(address hotel, address previousManager, address newManager);
 
-  /**
-   * @dev `setLifToken` allows the owner of the contract to change the
-   * address of the LifToken contract
-   * @param _LifToken The new contract address
-   */
-  function setLifToken(address _LifToken) onlyOwner public {
-    LifToken = _LifToken;
-  }
+    /**
+     * @dev Constructor. Creates the `WTIndex` contract
+     */
+    constructor() public {
+        hotels.length++;
+    }
 
-  /**
-   * @dev `registerHotel` Register new hotel in the index.
-   * Emits `HotelRegistered` on success.
-   * @param  dataUri Hotel's data pointer
-   */
-  function registerHotel(string dataUri) external {
-    Hotel newHotel = new Hotel(msg.sender, dataUri, this);
-    hotelsIndex[newHotel] = hotels.length;
-    hotels.push(newHotel);
-    hotelsByManagerIndex[newHotel] = hotelsByManager[msg.sender].length;
-    hotelsByManager[msg.sender].push(newHotel);
-    emit HotelRegistered(newHotel, hotelsByManagerIndex[newHotel], hotelsIndex[newHotel]);
-	}
+    /**
+     * @dev `registerHotel` Register new hotel in the index.
+     * Emits `HotelRegistered` on success.
+     * @param  dataUri Hotel's data pointer
+     */
+    function registerHotel(string dataUri) external {
+        Hotel newHotel = new Hotel(msg.sender, dataUri, this);
+        hotelsIndex[newHotel] = hotels.length;
+        hotels.push(newHotel);
+        hotelsByManagerIndex[newHotel] = hotelsByManager[msg.sender].length;
+        hotelsByManager[msg.sender].push(newHotel);
+        emit HotelRegistered(newHotel, hotelsByManagerIndex[newHotel], hotelsIndex[newHotel]);
+    }
 
-  /**
-   * @dev `deleteHotel` Allows a manager to delete a hotel, i. e. call destroy
-   * on the target Hotel contract. Emits `HotelDeleted` on success.
-   * @param  hotel  Hotel's address
-   */
-  function deleteHotel(address hotel) external {
-    // Ensure hotel address is valid
-    require(hotel != address(0));
-    // Ensure we know about the hotel at all
-    require(hotelsIndex[hotel] != uint(0));
-    // Ensure that the caller is the hotel's rightful owner
-    // There may actually be a hotel on index zero, that's why we use a double check
-    require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
+    /**
+     * @dev `deleteHotel` Allows a manager to delete a hotel, i. e. call destroy
+     * on the target Hotel contract. Emits `HotelDeleted` on success.
+     * @param  hotel  Hotel's address
+     */
+    function deleteHotel(address hotel) external {
+        // Ensure hotel address is valid
+        require(hotel != address(0));
+        // Ensure we know about the hotel at all
+        require(hotelsIndex[hotel] != uint(0));
+        // Ensure that the caller is the hotel's rightful owner
+        // There may actually be a hotel on index zero, that's why we use a double check
+        require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
 
-    Hotel hotelInstance = Hotel(hotel);
-    // Ensure we are calling only our own hotels
-    require(hotelInstance.index() == address(this));
-    hotelInstance.destroy();
-    
-    uint index = hotelsByManagerIndex[hotel];
-    uint allIndex = hotelsIndex[hotel];
-    delete hotels[allIndex];
-    delete hotelsIndex[hotel];
-    delete hotelsByManager[msg.sender][index];
-    delete hotelsByManagerIndex[hotel];
-    emit HotelDeleted(hotel, index, allIndex);
-	}
+        Hotel hotelInstance = Hotel(hotel);
+        // Ensure we are calling only our own hotels
+        require(hotelInstance.index() == address(this));
+        hotelInstance.destroy();
 
-  /**
-   * @dev `callHotel` Call hotel in the index, the hotel can only
-   * be called by its manager. Effectively proxies a hotel call.
-   * Emits HotelCalled on success.
-   * @param  hotel Hotel's address
-   * @param  data Encoded method call to be done on Hotel contract.
-   */
-	function callHotel(address hotel, bytes data) external {
-    // Ensure hotel address is valid
-    require(hotel != address(0));
-    // Ensure we know about the hotel at all
-    require(hotelsIndex[hotel] != uint(0));
-    // Ensure that the caller is the hotel's rightful owner
-    require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
-    Hotel hotelInstance = Hotel(hotel);
-    // Ensure we are calling only our own hotels
-    require(hotelInstance.index() == address(this));
-    require(hotel.call(data));
-    emit HotelCalled(hotel);
-	}
+        uint index = hotelsByManagerIndex[hotel];
+        uint allIndex = hotelsIndex[hotel];
+        delete hotels[allIndex];
+        delete hotelsIndex[hotel];
+        delete hotelsByManager[msg.sender][index];
+        delete hotelsByManagerIndex[hotel];
+        emit HotelDeleted(hotel, index, allIndex);
+    }
 
-  function transferHotel(address hotel, address newManager) external {
-    // Ensure hotel address is valid
-    require(hotel != address(0));
-    // Ensure new manager is valid
-    require(newManager != address(0));
-    // Ensure we know about the hotel at all
-    require(hotelsIndex[hotel] != uint(0));
-    // Ensure that the caller is the hotel's rightful owner
-    // There may actually be a hotel on index zero, that's why we use a double check
-    require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
+    /**
+     * @dev `callHotel` Call hotel in the index, the hotel can only
+     * be called by its manager. Effectively proxies a hotel call.
+     * Emits HotelCalled on success.
+     * @param  hotel Hotel's address
+     * @param  data Encoded method call to be done on Hotel contract.
+     */
+    function callHotel(address hotel, bytes data) external {
+        // Ensure hotel address is valid
+        require(hotel != address(0));
+        // Ensure we know about the hotel at all
+        require(hotelsIndex[hotel] != uint(0));
+        // Ensure that the caller is the hotel's rightful owner
+        require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
+        Hotel hotelInstance = Hotel(hotel);
+        // Ensure we are calling only our own hotels
+        require(hotelInstance.index() == address(this));
+        // solhint-disable-next-line avoid-low-level-calls
+        require(hotel.call(data));
+        emit HotelCalled(hotel);
+    }
 
-    Hotel hotelInstance = Hotel(hotel);
-    // Ensure we are calling only our own hotels
-    require(hotelInstance.index() == address(this));
-    // Change ownership in the Hotel contract
-    hotelInstance.changeManager(newManager);
-    
-    // Detach from the old manager ...
-    uint index = hotelsByManagerIndex[hotel];
-    delete hotelsByManager[msg.sender][index];
-    // ... and attach to new manager
-    hotelsByManagerIndex[hotel] = hotelsByManager[newManager].length;
-    hotelsByManager[newManager].push(hotel);
-    emit HotelTransferred(hotel, msg.sender, newManager);
-  }
+    /**
+     * @dev `transferHotel` Allows to change ownership of
+     * the hotel contract. Emits HotelTransferred on success.
+     * @param hotel Hotel's address
+     * @param newManager Address to which the hotel will belong after transfer.
+     */
+    function transferHotel(address hotel, address newManager) external {
+        // Ensure hotel address is valid
+        require(hotel != address(0));
+        // Ensure new manager is valid
+        require(newManager != address(0));
+        // Ensure we know about the hotel at all
+        require(hotelsIndex[hotel] != uint(0));
+        // Ensure that the caller is the hotel's rightful owner
+        // There may actually be a hotel on index zero, that's why we use a double check
+        require(hotelsByManager[msg.sender][hotelsByManagerIndex[hotel]] != address(0));
 
-  /**
-   * @dev `getHotelsLength` get the length of the `hotels` array
-   * @return {" ": "Length of the hotels array. Might contain zero addresses."}
-   */
-  function getHotelsLength() view public returns (uint) {
-    return hotels.length;
-  }
+        Hotel hotelInstance = Hotel(hotel);
+        // Ensure we are calling only our own hotels
+        require(hotelInstance.index() == address(this));
+        // Change ownership in the Hotel contract
+        hotelInstance.changeManager(newManager);
 
-  /**
-   * @dev `getHotels` get `hotels` array
-   * @return {" ": "Array of hotel addresses. Might contain zero addresses."}
-   */
-  function getHotels() view public returns (address[]) {
-    return hotels;
-  }
+        // Detach from the old manager ...
+        uint index = hotelsByManagerIndex[hotel];
+        delete hotelsByManager[msg.sender][index];
+        // ... and attach to new manager
+        hotelsByManagerIndex[hotel] = hotelsByManager[newManager].length;
+        hotelsByManager[newManager].push(hotel);
+        emit HotelTransferred(hotel, msg.sender, newManager);
+    }
 
-  /**
-   * @dev `getHotelsByManager` get all the hotels belonging to one manager
-   * @param  manager Manager address
-   * @return {" ": "Array of hotels belonging to one manager. Might contain zero addresses."}
-   */
-	function getHotelsByManager(address manager) view public returns (address[]) {
-		return hotelsByManager[manager];
-	}
+    /**
+     * @dev `setLifToken` allows the owner of the contract to change the
+     * address of the LifToken contract
+     * @param _lifToken The new contract address
+     */
+    function setLifToken(address _lifToken) public onlyOwner {
+        LifToken = _lifToken;
+    }
 
+    /**
+     * @dev `getHotelsLength` get the length of the `hotels` array
+     * @return {" ": "Length of the hotels array. Might contain zero addresses."}
+     */
+    function getHotelsLength() public view returns (uint) {
+        return hotels.length;
+    }
+
+    /**
+     * @dev `getHotels` get `hotels` array
+     * @return {" ": "Array of hotel addresses. Might contain zero addresses."}
+     */
+    function getHotels() public view returns (address[]) {
+        return hotels;
+    }
+
+    /**
+     * @dev `getHotelsByManager` get all the hotels belonging to one manager
+     * @param  manager Manager address
+     * @return {" ": "Array of hotels belonging to one manager. Might contain zero addresses."}
+     */
+    function getHotelsByManager(address manager) public view returns (address[]) {
+        return hotelsByManager[manager];
+    }
 }

--- a/contracts/hotel/AbstractHotel.sol
+++ b/contracts/hotel/AbstractHotel.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 
 import "../AbstractBaseContract.sol";
+
 
 /**
  * @title AbstractHotel
@@ -9,53 +10,53 @@ import "../AbstractBaseContract.sol";
  */
 contract AbstractHotel is AbstractBaseContract {
 
-  // Who owns this Hotel and can manage it.
-  address public manager;
+    // Who owns this Hotel and can manage it.
+    address public manager;
 
-  // Arbitrary locator of the off-chain stored hotel data
-  // This might be an HTTPS resource, IPFS hash, Swarm address...
-  // This is intentionally generic.
-  string public dataUri;
-  // Number of block when the Hotel was created
-  uint public created;
+    // Arbitrary locator of the off-chain stored hotel data
+    // This might be an HTTPS resource, IPFS hash, Swarm address...
+    // This is intentionally generic.
+    string public dataUri;
 
-  // WTIndex address
-  address public index;
+    // Number of block when the Hotel was created
+    uint public created;
 
-  /**
-   * Allows calling such methods only when msg.sender is equal
-   * to previously set index propert.y
-   */
-  modifier onlyFromIndex() {
-    require(msg.sender == index);
-    _;
-  }
+    // WTIndex address
+    address public index;
 
+    /**
+     * Allows calling such methods only when msg.sender is equal
+     * to previously set index propert.y
+     */
+    modifier onlyFromIndex() {
+        require(msg.sender == index);
+        _;
+    }
 
-  function _editInfoImpl(string _dataUri) internal;
-  function _destroyImpl() internal;
-  function _changeManagerImpl(address _newManager) internal;
+    /**
+     * @dev `editInfo` Allows owner to change hotel's dataUri.
+     * @param  _dataUri New dataUri pointer of this hotel
+     */
+    function editInfo(string _dataUri) public onlyFromIndex {
+        _editInfoImpl(_dataUri);
+    }
 
-  /**
-   * @dev `editInfo` Allows owner to change hotel's dataUri.
-   * @param  _dataUri New dataUri pointer of this hotel
-   */
-  function editInfo(string _dataUri) onlyFromIndex public {
-    _editInfoImpl(_dataUri);
-  }
+    /**
+     * @dev `destroy` allows the owner to delete the Hotel
+     */
+    function destroy() public onlyFromIndex {
+        _destroyImpl();
+    }
 
-  /**
-   * @dev `destroy` allows the owner to delete the Hotel
-   */
-  function destroy() onlyFromIndex public {
-    _destroyImpl();
-  }
+    /**
+     * @dev Allows owner to change hotel manager.
+     * @param _newManager New manager's address
+     */
+    function changeManager(address _newManager) public onlyFromIndex {
+        _changeManagerImpl(_newManager);
+    }
 
-  /**
-   * @dev Allows owner to change hotel manager.
-   * @param _newManager New manager's address
-   */
-  function changeManager(address _newManager) onlyFromIndex public {
-    _changeManagerImpl(_newManager);
-  }
+    function _editInfoImpl(string _dataUri) internal;
+    function _destroyImpl() internal;
+    function _changeManagerImpl(address _newManager) internal;
 }

--- a/contracts/hotel/Hotel.sol
+++ b/contracts/hotel/Hotel.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 
 import "./AbstractHotel.sol";
+
 
 /**
  * @title Hotel, contract for a Hotel registered in the WT network
@@ -9,36 +10,35 @@ import "./AbstractHotel.sol";
  */
 contract Hotel is AbstractHotel {
 
-  bytes32 public contractType = bytes32("hotel");
+    bytes32 public contractType = bytes32("hotel");
 
-  /**
-   * @dev Constructor.
-   * @param _manager address of hotel owner
-   * @param _dataUri pointer to hotel data
-   * @param _index originating WTIndex address
-   */
-  constructor(address _manager, string _dataUri, address _index) public {
-    require(_manager != address(0));
-    require(_index != address(0));
-    require(bytes(_dataUri).length != 0);
-    manager = _manager;
-    index = _index;
-    dataUri = _dataUri;
-    created = block.number;
-  }
+    /**
+     * @dev Constructor.
+     * @param _manager address of hotel owner
+     * @param _dataUri pointer to hotel data
+     * @param _index originating WTIndex address
+     */
+    constructor(address _manager, string _dataUri, address _index) public {
+        require(_manager != address(0));
+        require(_index != address(0));
+        require(bytes(_dataUri).length != 0);
+        manager = _manager;
+        index = _index;
+        dataUri = _dataUri;
+        created = block.number;
+    }
 
-  function _editInfoImpl(string _dataUri) internal {
-    require(bytes(_dataUri).length != 0);
-    dataUri = _dataUri;
-  }
+    function _editInfoImpl(string _dataUri) internal {
+        require(bytes(_dataUri).length != 0);
+        dataUri = _dataUri;
+    }
 
-  function _destroyImpl() internal {
-    selfdestruct(manager);
-  }
+    function _destroyImpl() internal {
+        selfdestruct(manager);
+    }
 
-  function _changeManagerImpl(address _newManager) internal {
-    require(_newManager != address(0));
-    manager = _newManager;
-  }
-
+    function _changeManagerImpl(address _newManager) internal {
+        require(_newManager != address(0));
+        manager = _newManager;
+    }
 }

--- a/docs/WTIndex.md
+++ b/docs/WTIndex.md
@@ -71,13 +71,14 @@ Inputs
 
 WTIndex.transferHotel(hotel, newManager) `nonpayable` `292d64e0`
 
+> `transferHotel` Allows to change ownership of the hotel contract. Emits HotelTransferred on success.
 
 Inputs
 
 | **type** | **name** | **description** |
 |-|-|-|
-| *address* | hotel | undefined |
-| *address* | newManager | undefined |
+| *address* | hotel | Hotel's address |
+| *address* | newManager | Address to which the hotel will belong after transfer. |
 
 
 ## *function* version
@@ -194,7 +195,7 @@ Inputs
 
 ## *function* setLifToken
 
-WTIndex.setLifToken(_LifToken) `nonpayable` `f2f0967b`
+WTIndex.setLifToken(_lifToken) `nonpayable` `f2f0967b`
 
 > `setLifToken` allows the owner of the contract to change the address of the LifToken contract
 
@@ -202,7 +203,7 @@ Inputs
 
 | **type** | **name** | **description** |
 |-|-|-|
-| *address* | _LifToken | The new contract address |
+| *address* | _lifToken | The new contract address |
 
 
 ## *function* transferOwnership

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,6 +184,12 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "antlr4": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.7.0.tgz",
+      "integrity": "sha1-KX+VbdwG+DOX/AmQ7PLgzyC/u+4=",
+      "dev": true
+    },
     "any-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
@@ -8377,6 +8383,21 @@
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
       "integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg=="
     },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
     "rxjs": {
       "version": "5.5.11",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
@@ -8815,6 +8836,263 @@
           "requires": {
             "camelcase": "^3.0.0",
             "lodash.assign": "^4.0.6"
+          }
+        }
+      }
+    },
+    "solhint": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-1.2.1.tgz",
+      "integrity": "sha512-3B0ydhkOlicyyTmKnwJC6kiwdJUXvbbDYXcy8m7rznoQPgzzkmSOsJgb9BAe+KBQP5BD3PLgcoOQ84t3FSxqsQ==",
+      "dev": true,
+      "requires": {
+        "antlr4": "4.7.0",
+        "commander": "2.11.0",
+        "eslint": "^4.19.1",
+        "glob": "7.1.2",
+        "ignore": "^3.3.7",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "scripts/test.sh",
-    "lint": "eslint test",
+    "lint": "eslint test; solhint 'contracts/**/*.sol'",
     "testrpc": "./node_modules/.bin/ganache-cli",
     "coverage": "SOLIDITY_COVERAGE=true npm run test",
     "soldoc": "scripts/soldoc.sh",
@@ -55,6 +55,7 @@
     "ganache-cli": "^6.1.6",
     "lodash": "^4.17.5",
     "rimraf": "^2.6.2",
+    "solhint": "^1.2.1",
     "solidity-coverage": "^0.5.5",
     "solmd": "^0.3.0",
     "truffle": "^4.1.13",


### PR DESCRIPTION
I've recently found out about [solhint](https://github.com/protofire/solhint) which does the same thing as eslint, only on solidity code.

There are no breaking changes, only some indentation issues and function ordering. I have disabled linting on the lines that would have break things.

edit: We could put it into lif-token as well, but I'm not sure if we want to modify the already deployed and used code, such as MVM.