### PR TITLE
Add Liftoken

### DIFF
--- a/contracts/LifToken.sol
+++ b/contracts/LifToken.sol
@@ -439,7 +439,7 @@ contract LifToken is StandardToken, MintableToken, PausableToken {
   }
 }
 
-contract LifTokenMock is LifToken {
+contract LifTokenTest is LifToken {
   constructor(address addr, uint256 initialBalance) public {
       totalSupply_ = totalSupply_.add(initialBalance);
       balances[addr] = balances[addr].add(initialBalance);

--- a/contracts/LifToken.sol
+++ b/contracts/LifToken.sol
@@ -1,0 +1,447 @@
+pragma solidity >0.4.18;
+
+// File: zeppelin-solidity/contracts/ownership/Ownable.sol
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable {
+  address public owner;
+
+
+  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+
+  /**
+   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+   * account.
+   */
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address newOwner) public onlyOwner {
+    require(newOwner != address(0));
+    emit OwnershipTransferred(owner, newOwner);
+    owner = newOwner;
+  }
+
+}
+
+// File: zeppelin-solidity/contracts/math/SafeMath.sol
+
+/**
+ * @title SafeMath
+ * @dev Math operations with safety checks that throw on error
+ */
+library SafeMath {
+
+  /**
+  * @dev Multiplies two numbers, throws on overflow.
+  */
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    if (a == 0) {
+      return 0;
+    }
+    uint256 c = a * b;
+    assert(c / a == b);
+    return c;
+  }
+
+  /**
+  * @dev Integer division of two numbers, truncating the quotient.
+  */
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    // assert(b > 0); // Solidity automatically throws when dividing by 0
+    uint256 c = a / b;
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+    return c;
+  }
+
+  /**
+  * @dev Substracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+  */
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    assert(b <= a);
+    return a - b;
+  }
+
+  /**
+  * @dev Adds two numbers, throws on overflow.
+  */
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
+    uint256 c = a + b;
+    assert(c >= a);
+    return c;
+  }
+}
+
+// File: zeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol
+
+/**
+ * @title ERC20Basic
+ * @dev Simpler version of ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/179
+ */
+contract ERC20Basic {
+  function totalSupply() public view returns (uint256);
+  function balanceOf(address who) public view returns (uint256);
+  function transfer(address to, uint256 value) public returns (bool);
+  event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+// File: zeppelin-solidity/contracts/token/ERC20/BasicToken.sol
+
+/**
+ * @title Basic token
+ * @dev Basic version of StandardToken, with no allowances.
+ */
+contract BasicToken is ERC20Basic {
+  using SafeMath for uint256;
+
+  mapping(address => uint256) balances;
+
+  uint256 totalSupply_;
+
+  /**
+  * @dev total number of tokens in existence
+  */
+  function totalSupply() public view returns (uint256) {
+    return totalSupply_;
+  }
+
+  /**
+  * @dev transfer token for a specified address
+  * @param _to The address to transfer to.
+  * @param _value The amount to be transferred.
+  */
+  function transfer(address _to, uint256 _value) public returns (bool) {
+    require(_to != address(0));
+    require(_value <= balances[msg.sender]);
+
+    // SafeMath.sub will throw if there is not enough balance.
+    balances[msg.sender] = balances[msg.sender].sub(_value);
+    balances[_to] = balances[_to].add(_value);
+    emit Transfer(msg.sender, _to, _value);
+    return true;
+  }
+
+  /**
+  * @dev Gets the balance of the specified address.
+  * @param _owner The address to query the the balance of.
+  * @return An uint256 representing the amount owned by the passed address.
+  */
+  function balanceOf(address _owner) public view returns (uint256 balance) {
+    return balances[_owner];
+  }
+
+}
+
+// File: zeppelin-solidity/contracts/token/ERC20/ERC20.sol
+
+/**
+ * @title ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/20
+ */
+contract ERC20 is ERC20Basic {
+  function allowance(address owner, address spender) public view returns (uint256);
+  function transferFrom(address from, address to, uint256 value) public returns (bool);
+  function approve(address spender, uint256 value) public returns (bool);
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+// File: zeppelin-solidity/contracts/token/ERC20/StandardToken.sol
+
+/**
+ * @title Standard ERC20 token
+ *
+ * @dev Implementation of the basic standard token.
+ * @dev https://github.com/ethereum/EIPs/issues/20
+ * @dev Based on code by FirstBlood: https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
+ */
+contract StandardToken is ERC20, BasicToken {
+
+  mapping (address => mapping (address => uint256)) internal allowed;
+
+
+  /**
+   * @dev Transfer tokens from one address to another
+   * @param _from address The address which you want to send tokens from
+   * @param _to address The address which you want to transfer to
+   * @param _value uint256 the amount of tokens to be transferred
+   */
+  function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
+    require(_to != address(0));
+    require(_value <= balances[_from]);
+    require(_value <= allowed[_from][msg.sender]);
+
+    balances[_from] = balances[_from].sub(_value);
+    balances[_to] = balances[_to].add(_value);
+    allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
+    emit Transfer(_from, _to, _value);
+    return true;
+  }
+
+  /**
+   * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+   *
+   * Beware that changing an allowance with this method brings the risk that someone may use both the old
+   * and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
+   * race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
+   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+   * @param _spender The address which will spend the funds.
+   * @param _value The amount of tokens to be spent.
+   */
+  function approve(address _spender, uint256 _value) public returns (bool) {
+    allowed[msg.sender][_spender] = _value;
+    emit Approval(msg.sender, _spender, _value);
+    return true;
+  }
+
+  /**
+   * @dev Function to check the amount of tokens that an owner allowed to a spender.
+   * @param _owner address The address which owns the funds.
+   * @param _spender address The address which will spend the funds.
+   * @return A uint256 specifying the amount of tokens still available for the spender.
+   */
+  function allowance(address _owner, address _spender) public view returns (uint256) {
+    return allowed[_owner][_spender];
+  }
+
+  /**
+   * @dev Increase the amount of tokens that an owner allowed to a spender.
+   *
+   * approve should be called when allowed[_spender] == 0. To increment
+   * allowed value is better to use this function to avoid 2 calls (and wait until
+   * the first transaction is mined)
+   * From MonolithDAO Token.sol
+   * @param _spender The address which will spend the funds.
+   * @param _addedValue The amount of tokens to increase the allowance by.
+   */
+  function increaseApproval(address _spender, uint _addedValue) public returns (bool) {
+    allowed[msg.sender][_spender] = allowed[msg.sender][_spender].add(_addedValue);
+    emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+    return true;
+  }
+
+  /**
+   * @dev Decrease the amount of tokens that an owner allowed to a spender.
+   *
+   * approve should be called when allowed[_spender] == 0. To decrement
+   * allowed value is better to use this function to avoid 2 calls (and wait until
+   * the first transaction is mined)
+   * From MonolithDAO Token.sol
+   * @param _spender The address which will spend the funds.
+   * @param _subtractedValue The amount of tokens to decrease the allowance by.
+   */
+  function decreaseApproval(address _spender, uint _subtractedValue) public returns (bool) {
+    uint oldValue = allowed[msg.sender][_spender];
+    if (_subtractedValue > oldValue) {
+      allowed[msg.sender][_spender] = 0;
+    } else {
+      allowed[msg.sender][_spender] = oldValue.sub(_subtractedValue);
+    }
+    emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+    return true;
+  }
+
+}
+
+// File: zeppelin-solidity/contracts/token/ERC20/MintableToken.sol
+
+/**
+ * @title Mintable token
+ * @dev Simple ERC20 Token example, with mintable token creation
+ * @dev Issue: * https://github.com/OpenZeppelin/zeppelin-solidity/issues/120
+ * Based on code by TokenMarketNet: https://github.com/TokenMarketNet/ico/blob/master/contracts/MintableToken.sol
+ */
+contract MintableToken is StandardToken, Ownable {
+  event Mint(address indexed to, uint256 amount);
+  event MintFinished();
+
+  bool public mintingFinished = false;
+
+
+  modifier canMint() {
+    require(!mintingFinished);
+    _;
+  }
+
+  /**
+   * @dev Function to mint tokens
+   * @param _to The address that will receive the minted tokens.
+   * @param _amount The amount of tokens to mint.
+   * @return A boolean that indicates if the operation was successful.
+   */
+  function mint(address _to, uint256 _amount) onlyOwner canMint public returns (bool) {
+    totalSupply_ = totalSupply_.add(_amount);
+    balances[_to] = balances[_to].add(_amount);
+    emit Mint(_to, _amount);
+    emit Transfer(address(0), _to, _amount);
+    return true;
+  }
+
+  /**
+   * @dev Function to stop minting new tokens.
+   * @return True if the operation was successful.
+   */
+  function finishMinting() onlyOwner canMint public returns (bool) {
+    mintingFinished = true;
+    emit MintFinished();
+    return true;
+  }
+}
+
+// File: zeppelin-solidity/contracts/lifecycle/Pausable.sol
+
+/**
+ * @title Pausable
+ * @dev Base contract which allows children to implement an emergency stop mechanism.
+ */
+contract Pausable is Ownable {
+  event Pause();
+  event Unpause();
+
+  bool public paused = false;
+
+
+  /**
+   * @dev Modifier to make a function callable only when the contract is not paused.
+   */
+  modifier whenNotPaused() {
+    require(!paused);
+    _;
+  }
+
+  /**
+   * @dev Modifier to make a function callable only when the contract is paused.
+   */
+  modifier whenPaused() {
+    require(paused);
+    _;
+  }
+
+  /**
+   * @dev called by the owner to pause, triggers stopped state
+   */
+  function pause() onlyOwner whenNotPaused public {
+    paused = true;
+    emit Pause();
+  }
+
+  /**
+   * @dev called by the owner to unpause, returns to normal state
+   */
+  function unpause() onlyOwner whenPaused public {
+    paused = false;
+    emit Unpause();
+  }
+}
+
+// File: zeppelin-solidity/contracts/token/ERC20/PausableToken.sol
+
+/**
+ * @title Pausable token
+ * @dev StandardToken modified with pausable transfers.
+ **/
+contract PausableToken is StandardToken, Pausable {
+
+  function transfer(address _to, uint256 _value) public whenNotPaused returns (bool) {
+    return super.transfer(_to, _value);
+  }
+
+  function transferFrom(address _from, address _to, uint256 _value) public whenNotPaused returns (bool) {
+    return super.transferFrom(_from, _to, _value);
+  }
+
+  function approve(address _spender, uint256 _value) public whenNotPaused returns (bool) {
+    return super.approve(_spender, _value);
+  }
+
+  function increaseApproval(address _spender, uint _addedValue) public whenNotPaused returns (bool success) {
+    return super.increaseApproval(_spender, _addedValue);
+  }
+
+  function decreaseApproval(address _spender, uint _subtractedValue) public whenNotPaused returns (bool success) {
+    return super.decreaseApproval(_spender, _subtractedValue);
+  }
+}
+
+// File: contracts/LifToken.sol
+
+/**
+   @title Líf, the Winding Tree token
+
+   Implementation of Líf, the ERC827 token for Winding Tree, an extension of the
+   ERC20 token with extra methods to transfer value and data to execute a call
+   on transfer.
+   Uses OpenZeppelin StandardToken, ERC827Token, MintableToken and PausableToken.
+ */
+contract LifToken is StandardToken, MintableToken, PausableToken {
+  // Token Name
+  string public constant NAME = "Líf";
+
+  // Token Symbol
+  string public constant SYMBOL = "LIF";
+
+  // Token decimals
+  uint public constant DECIMALS = 18;
+
+  /**
+   * @dev Burns a specific amount of tokens.
+   *
+   * @param _value The amount of tokens to be burned.
+   */
+  function burn(uint256 _value) public whenNotPaused {
+
+    require(_value <= balances[msg.sender]);
+
+    balances[msg.sender] = balances[msg.sender].sub(_value);
+    totalSupply_ = totalSupply_.sub(_value);
+
+    // a Transfer event to 0x0 can be useful for observers to keep track of
+    // all the Lif by just looking at those events
+    emit Transfer(msg.sender, address(0), _value);
+  }
+
+  /**
+   * @dev Burns a specific amount of tokens of an address
+   * This function can be called only by the owner in the minting process
+   *
+   * @param _value The amount of tokens to be burned.
+   */
+  function burn(address burner, uint256 _value) public onlyOwner {
+
+    require(!mintingFinished);
+
+    require(_value <= balances[burner]);
+
+    balances[burner] = balances[burner].sub(_value);
+    totalSupply_ = totalSupply_.sub(_value);
+
+    // a Transfer event to 0x0 can be useful for observers to keep track of
+    // all the Lif by just looking at those events
+    emit Transfer(burner, address(0), _value);
+  }
+}
+
+contract LifTokenMock is LifToken {
+  constructor(address addr, uint256 initialBalance) public {
+      totalSupply_ = totalSupply_.add(initialBalance);
+      balances[addr] = balances[addr].add(initialBalance);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ethereumjs-util": "^6.1.0",
     "ganache-cli": "^6.4.1",
     "lodash": "^4.17.11",
+    "openzeppelin-test-helpers": "^0.3.2",
     "rimraf": "^2.6.3",
     "solc": "^0.5.7",
     "solhint": "^2.0.0",

--- a/test/LifToken.js
+++ b/test/LifToken.js
@@ -1,0 +1,70 @@
+const { TestHelper } = require('zos');
+const { Contracts, ZWeb3 } = require('zos-lib');
+const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-helpers');
+const assert = require('chai').assert;
+const help = require('./helpers/index.js');
+
+const LifTokenMock = artifacts.require('LifTokenMock');
+
+contract('LifToken', (accounts) => {
+  let token;
+
+  // Create the token with initial balance
+  beforeEach(async () => {
+    token = await LifTokenMock.new(accounts[1], 100);
+  });
+
+  it.only('should have the right initial balance and total supply', async () => {
+    assert.equal(await token.balanceOf(accounts[1]), 100);
+    assert.equal(await token.totalSupply(), 100);
+  });
+
+  it.only('should transfer tokens correctly', async () => {
+    await token.transfer(accounts[2], 10, { from: accounts[1] });
+    assert.equal(await token.balanceOf(accounts[1]), 90);
+    assert.equal(await token.balanceOf(accounts[2]), 10);
+  });
+
+  it.only('should approve tokens correctly', async () => {
+    await token.approve(accounts[2], 10, { from: accounts[1] });
+    assert.equal(await token.allowance(accounts[1], accounts[2]), 10);
+  });
+
+  it.only('should transfer approved tokens correctly', async () => {
+    await token.approve(accounts[2], 10, { from: accounts[1] });
+    await token.transferFrom(accounts[1], accounts[3], 10, { from: accounts[2] });
+    assert.equal(await token.balanceOf(accounts[1]), 90);
+    assert.equal(await token.balanceOf(accounts[3]), 10);
+  });
+
+  it.only('should increaseApproval tokens correctly', async () => {
+    await token.increaseApproval(accounts[2], 10, { from: accounts[1] });
+    assert.equal(await token.allowance(accounts[1], accounts[2]), 10);
+  });
+
+  it.only('should decreaseApproval tokens correctly', async () => {
+    await token.approve(accounts[2], 10, { from: accounts[1] });
+    await token.decreaseApproval(accounts[2], 10, { from: accounts[1] });
+    assert.equal(await token.allowance(accounts[1], accounts[2]), 0);
+  });
+
+  it.only('should not allow token actions while paused', async () => {
+    await token.pause();
+    await shouldFail.reverting(
+      token.transfer(accounts[2], 10, { from: accounts[1] })
+    );
+    await shouldFail.reverting(
+      token.approve(accounts[2], 10, { from: accounts[1] })
+    );
+    await shouldFail.reverting(
+      token.transferFrom(accounts[1], accounts[3], 10, { from: accounts[2] })
+    );
+    await shouldFail.reverting(
+      token.increaseApproval(accounts[2], 10, { from: accounts[1] })
+    );
+    await shouldFail.reverting(
+      token.decreaseApproval(accounts[2], 10, { from: accounts[1] })
+    );
+  });
+
+});

--- a/test/LifToken.js
+++ b/test/LifToken.js
@@ -4,51 +4,51 @@ const { BN, constants, expectEvent, shouldFail } = require('openzeppelin-test-he
 const assert = require('chai').assert;
 const help = require('./helpers/index.js');
 
-const LifTokenMock = artifacts.require('LifTokenMock');
+const LifTokenTest = artifacts.require('LifTokenTest');
 
 contract('LifToken', (accounts) => {
   let token;
 
   // Create the token with initial balance
   beforeEach(async () => {
-    token = await LifTokenMock.new(accounts[1], 100);
+    token = await LifTokenTest.new(accounts[1], 100);
   });
 
-  it.only('should have the right initial balance and total supply', async () => {
+  it('should have the right initial balance and total supply', async () => {
     assert.equal(await token.balanceOf(accounts[1]), 100);
     assert.equal(await token.totalSupply(), 100);
   });
 
-  it.only('should transfer tokens correctly', async () => {
+  it('should transfer tokens correctly', async () => {
     await token.transfer(accounts[2], 10, { from: accounts[1] });
     assert.equal(await token.balanceOf(accounts[1]), 90);
     assert.equal(await token.balanceOf(accounts[2]), 10);
   });
 
-  it.only('should approve tokens correctly', async () => {
+  it('should approve tokens correctly', async () => {
     await token.approve(accounts[2], 10, { from: accounts[1] });
     assert.equal(await token.allowance(accounts[1], accounts[2]), 10);
   });
 
-  it.only('should transfer approved tokens correctly', async () => {
+  it('should transfer approved tokens correctly', async () => {
     await token.approve(accounts[2], 10, { from: accounts[1] });
     await token.transferFrom(accounts[1], accounts[3], 10, { from: accounts[2] });
     assert.equal(await token.balanceOf(accounts[1]), 90);
     assert.equal(await token.balanceOf(accounts[3]), 10);
   });
 
-  it.only('should increaseApproval tokens correctly', async () => {
+  it('should increaseApproval tokens correctly', async () => {
     await token.increaseApproval(accounts[2], 10, { from: accounts[1] });
     assert.equal(await token.allowance(accounts[1], accounts[2]), 10);
   });
 
-  it.only('should decreaseApproval tokens correctly', async () => {
+  it('should decreaseApproval tokens correctly', async () => {
     await token.approve(accounts[2], 10, { from: accounts[1] });
     await token.decreaseApproval(accounts[2], 10, { from: accounts[1] });
     assert.equal(await token.allowance(accounts[1], accounts[2]), 0);
   });
 
-  it.only('should not allow token actions while paused', async () => {
+  it('should not allow token actions while paused', async () => {
     await token.pause();
     await shouldFail.reverting(
       token.transfer(accounts[2], 10, { from: accounts[1] })

--- a/test/wt-airline.js
+++ b/test/wt-airline.js
@@ -14,24 +14,26 @@ const WTAirline = Contracts.getFromLocal('Airline');
 // eaiser interaction with truffle-contract
 const AbstractWTAirline = artifacts.require('AbstractAirline');
 const AbstractWTAirlineIndex = artifacts.require('AbstractWTAirlineIndex');
+const LifTokenTest = artifacts.require('LifTokenTest');
 
 contract('Airline', (accounts) => {
   const airlineUri = 'bzz://something';
   const indexOwner = accounts[1];
   const airlineAccount = accounts[2];
   const nonOwnerAccount = accounts[3];
-  const tokenAddress = accounts[5];
   let project;
   let airlineAddress = help.zeroAddress;
   let wtAirlineIndex;
   let wtAirline;
+  let token;
 
   // Create and register a airline
   beforeEach(async () => {
     project = await TestHelper();
+    token = await LifTokenTest.new(accounts[1], 100);
     const airlineIndexProxy = await project.createProxy(WTAirlineIndex, {
       initFunction: 'initialize',
-      initArgs: [indexOwner, tokenAddress],
+      initArgs: [indexOwner, token.address],
     });
     wtAirlineIndex = await AbstractWTAirlineIndex.at(airlineIndexProxy.address);
     await wtAirlineIndex.registerAirline(airlineUri, { from: airlineAccount });

--- a/test/wt-hotel.js
+++ b/test/wt-hotel.js
@@ -14,24 +14,26 @@ const WTHotel = Contracts.getFromLocal('Hotel');
 // eaiser interaction with truffle-contract
 const AbstractWTHotel = artifacts.require('AbstractHotel');
 const AbstractWTHotelIndex = artifacts.require('AbstractWTHotelIndex');
+const LifTokenTest = artifacts.require('LifTokenTest');
 
 contract('Hotel', (accounts) => {
   const hotelUri = 'bzz://something';
   const indexOwner = accounts[1];
   const hotelAccount = accounts[2];
   const nonOwnerAccount = accounts[3];
-  const tokenAddress = accounts[5];
   let project;
   let hotelAddress = help.zeroAddress;
   let wtHotelIndex;
   let wtHotel;
+  let token;
 
   // Create and register a hotel
   beforeEach(async () => {
     project = await TestHelper();
+    token = await LifTokenTest.new(accounts[1], 100);
     const hotelIndexProxy = await project.createProxy(WTHotelIndex, {
       initFunction: 'initialize',
-      initArgs: [indexOwner, tokenAddress],
+      initArgs: [indexOwner, token.address],
     });
     wtHotelIndex = await AbstractWTHotelIndex.at(hotelIndexProxy.address);
     await wtHotelIndex.registerHotel(hotelUri, { from: hotelAccount });


### PR DESCRIPTION
Add the LifTokenm contract deployed on https://etherscan.io/address/0xeb9951021698b42e4399f9cbb6267aa35f82d59d

The contract methods and compatibility with the contract mainnent is the same, the only differences is the function constructor that was replaced for constructor and added the emit keyword in front of all events.

Also the LifTokenTest contract was added, can be used for testing, where a token is created with abalnce on only one account.