### PR TITLE
Trusted addresses/organization's delegates

### DIFF
--- a/contracts/OrganizationInterface.sol
+++ b/contracts/OrganizationInterface.sol
@@ -3,4 +3,5 @@ pragma solidity ^0.5.6;
 contract OrganizationInterface {
     function owner() public view returns (address);
     function getDataUri() external view returns (string memory);
+    function isDelegate(address addr) external view returns(bool);
 }

--- a/contracts/SegmentDirectory.sol
+++ b/contracts/SegmentDirectory.sol
@@ -61,7 +61,7 @@ contract SegmentDirectory is Initializable, SegmentDirectoryEvents {
     function addOrganization(address organization) internal returns (address) {
         // this is intentionally not part of the state variables as we expect it to change in time.
         require(organizationsIndex[organization] == 0, 'Cannot add organization twice');
-        bytes4 _INTERFACE_ID_ORGANIZATION = 0xe8570cfc;
+        bytes4 _INTERFACE_ID_ORGANIZATION = 0xef209adb;
         require(ERC165Checker._supportsInterface(organization, _INTERFACE_ID_ORGANIZATION));
         OrganizationInterface org = OrganizationInterface(organization);
         require(org.owner() == msg.sender, 'Only organization owner can register the organization');

--- a/docs/Organization.md
+++ b/docs/Organization.md
@@ -1,15 +1,22 @@
 * [Organization](#organization)
   * [supportsInterface](#function-supportsinterface)
+  * [isDelegate](#function-isdelegate)
   * [changeDataUri](#function-changedatauri)
   * [created](#function-created)
   * [getDataUri](#function-getdatauri)
+  * [removeDelegate](#function-removedelegate)
   * [renounceOwnership](#function-renounceownership)
   * [dataUri](#function-datauri)
   * [owner](#function-owner)
   * [isOwner](#function-isowner)
+  * [delegates](#function-delegates)
+  * [delegatesIndex](#function-delegatesindex)
+  * [addDelegate](#function-adddelegate)
   * [transferOwnership](#function-transferownership)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [DataUriChanged](#event-dataurichanged)
+  * [DelegateAdded](#event-delegateadded)
+  * [DelegateRemoved](#event-delegateremoved)
 
 # Organization
 
@@ -26,6 +33,24 @@ Inputs
 |-|-|-|
 | *bytes4* | interfaceId | undefined |
 
+
+## *function* isDelegate
+
+Organization.isDelegate(addr) `view` `07779627`
+
+> Is an address considered a delegate for this organization?
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | undefined |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* |  | undefined |
 
 ## *function* changeDataUri
 
@@ -62,6 +87,19 @@ Outputs
 |-|-|-|
 | *string* |  | undefined |
 
+## *function* removeDelegate
+
+Organization.removeDelegate(addr) `nonpayable` `67e7646f`
+
+> Removes delegate address. Only owner can call this.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | Delegate's Ethereum address |
+
+
 ## *function* renounceOwnership
 
 Organization.renounceOwnership() `nonpayable` `715018a6`
@@ -97,6 +135,48 @@ Organization.isOwner() `view` `8f32d59b`
 
 
 
+## *function* delegates
+
+Organization.delegates() `view` `b1548afc`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* delegatesIndex
+
+Organization.delegatesIndex() `view` `c72934d5`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
+
+
+## *function* addDelegate
+
+Organization.addDelegate(addr) `nonpayable` `e71bdf41`
+
+> Adds new delegate address. Only owner can call this.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | Delegate's Ethereum address |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
+
 ## *function* transferOwnership
 
 Organization.transferOwnership(newOwner) `nonpayable` `f2fde38b`
@@ -131,6 +211,27 @@ Arguments
 |-|-|-|
 | *string* | previousDataUri | indexed |
 | *string* | newDataUri | indexed |
+
+## *event* DelegateAdded
+
+Organization.DelegateAdded(delegate, index) `ea230cdd`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | delegate | indexed |
+| *uint256* | index | not indexed |
+
+## *event* DelegateRemoved
+
+Organization.DelegateRemoved(delegate) `5a362b19`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | delegate | indexed |
 
 
 ---

--- a/docs/OrganizationInterface.md
+++ b/docs/OrganizationInterface.md
@@ -1,8 +1,21 @@
 * [OrganizationInterface](#organizationinterface)
+  * [isDelegate](#function-isdelegate)
   * [getDataUri](#function-getdatauri)
   * [owner](#function-owner)
 
 # OrganizationInterface
+
+
+## *function* isDelegate
+
+OrganizationInterface.isDelegate(addr) `view` `07779627`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | undefined |
 
 
 ## *function* getDataUri

--- a/docs/OrganizationUpgradeabilityTest.md
+++ b/docs/OrganizationUpgradeabilityTest.md
@@ -1,16 +1,23 @@
 * [OrganizationUpgradeabilityTest](#organizationupgradeabilitytest)
   * [supportsInterface](#function-supportsinterface)
+  * [isDelegate](#function-isdelegate)
   * [changeDataUri](#function-changedatauri)
   * [newFunction](#function-newfunction)
   * [created](#function-created)
   * [getDataUri](#function-getdatauri)
+  * [removeDelegate](#function-removedelegate)
   * [renounceOwnership](#function-renounceownership)
   * [dataUri](#function-datauri)
   * [owner](#function-owner)
   * [isOwner](#function-isowner)
+  * [delegates](#function-delegates)
+  * [delegatesIndex](#function-delegatesindex)
+  * [addDelegate](#function-adddelegate)
   * [transferOwnership](#function-transferownership)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [DataUriChanged](#event-dataurichanged)
+  * [DelegateAdded](#event-delegateadded)
+  * [DelegateRemoved](#event-delegateremoved)
 
 # OrganizationUpgradeabilityTest
 
@@ -27,6 +34,24 @@ Inputs
 |-|-|-|
 | *bytes4* | interfaceId | undefined |
 
+
+## *function* isDelegate
+
+OrganizationUpgradeabilityTest.isDelegate(addr) `view` `07779627`
+
+> Is an address considered a delegate for this organization?
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | undefined |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bool* |  | undefined |
 
 ## *function* changeDataUri
 
@@ -71,6 +96,19 @@ Outputs
 |-|-|-|
 | *string* |  | undefined |
 
+## *function* removeDelegate
+
+OrganizationUpgradeabilityTest.removeDelegate(addr) `nonpayable` `67e7646f`
+
+> Removes delegate address. Only owner can call this.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | Delegate's Ethereum address |
+
+
 ## *function* renounceOwnership
 
 OrganizationUpgradeabilityTest.renounceOwnership() `nonpayable` `715018a6`
@@ -106,6 +144,48 @@ OrganizationUpgradeabilityTest.isOwner() `view` `8f32d59b`
 
 
 
+## *function* delegates
+
+OrganizationUpgradeabilityTest.delegates() `view` `b1548afc`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *uint256* |  | undefined |
+
+
+## *function* delegatesIndex
+
+OrganizationUpgradeabilityTest.delegatesIndex() `view` `c72934d5`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
+
+
+## *function* addDelegate
+
+OrganizationUpgradeabilityTest.addDelegate(addr) `nonpayable` `e71bdf41`
+
+> Adds new delegate address. Only owner can call this.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | addr | Delegate's Ethereum address |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
+
 ## *function* transferOwnership
 
 OrganizationUpgradeabilityTest.transferOwnership(newOwner) `nonpayable` `f2fde38b`
@@ -140,6 +220,27 @@ Arguments
 |-|-|-|
 | *string* | previousDataUri | indexed |
 | *string* | newDataUri | indexed |
+
+## *event* DelegateAdded
+
+OrganizationUpgradeabilityTest.DelegateAdded(delegate, index) `ea230cdd`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | delegate | indexed |
+| *uint256* | index | not indexed |
+
+## *event* DelegateRemoved
+
+OrganizationUpgradeabilityTest.DelegateRemoved(delegate) `5a362b19`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | delegate | indexed |
 
 
 ---


### PR DESCRIPTION
Closes #238 

The idea is to have a list of delegates that can sign messages on behalf of the organization. This smart-contract based list managed by the organization owner can serve as a source of truth for verification of incoming messages.

The implementation is kind of one-sided, but it can be altered to require the delegates to approve their inclusion in the list in the future. With #218 it would be quite easy to change the logic and we should encourage external organization implementations to be upgradeable as well.