### PR TITLE
Feat/upgradeable organization

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,7 +1,8 @@
 module.exports = {
   norpc: true,
+  deepSkip: true,
   copyPackages: [
-    'zos-lib',
+    // 'zos-lib', // Including this package breaks coverage process due crappy code style in the zos-lib/.../App.sol
     'zos',
     'openzeppelin-solidity',
   ]

--- a/contracts/Organization.sol
+++ b/contracts/Organization.sol
@@ -1,14 +1,16 @@
 pragma solidity ^0.5.6;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/introspection/ERC165.sol";
 import "./OrganizationInterface.sol";
+import "zos-lib/contracts/Initializable.sol";
 
 /**
  * @title Organization
  * @dev A contract that represents an Organization in the Winding Tree platform.
  */
-contract Organization is OrganizationInterface, ERC165, Ownable {
+contract Organization is OrganizationInterface, ERC165, Initializable {
+    // Address of the contract owner
+    address _owner;
 
     // Arbitrary locator of the off-chain stored Organization data
     // This might be an HTTPS resource, IPFS hash, Swarm address...
@@ -49,16 +51,29 @@ contract Organization is OrganizationInterface, ERC165, Ownable {
     event DelegateRemoved(address indexed delegate);
 
     /**
-     * @dev Constructor.
+     * @dev Initializer for upgradeable contracts.
+     * @param __owner The address of the contract owner
      * @param _dataUri pointer to Organization data
      */
-    constructor(string memory _dataUri) public {
+    function initialize(address payable __owner, string memory _dataUri) public initializer {
+        require(__owner != address(0), 'Cannot set owner to 0x0 address');
         require(bytes(_dataUri).length != 0, 'dataUri cannot be an empty string');
+        emit OwnershipTransferred(_owner, __owner);
+        _owner = __owner;        
         dataUri = _dataUri;
         created = block.number;
         delegates.length++;
         OrganizationInterface i;
+        _registerInterface(0x01ffc9a7);//_INTERFACE_ID_ERC165
         _registerInterface(i.owner.selector ^ i.getDataUri.selector ^ i.isDelegate.selector);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == _owner);
+        _;
     }
 
     /**
@@ -66,8 +81,7 @@ contract Organization is OrganizationInterface, ERC165, Ownable {
      * @param  _dataUri New dataUri pointer of this Organization
      */
     function changeDataUri(string memory _dataUri) public onlyOwner {
-        bytes memory tempStringRepr = bytes(_dataUri);
-        require(tempStringRepr.length != 0, 'dataUri cannot be an empty string');
+        require(bytes(_dataUri).length != 0, 'dataUri cannot be an empty string');
         emit DataUriChanged(dataUri, _dataUri);
         dataUri = _dataUri;
     }
@@ -112,5 +126,22 @@ contract Organization is OrganizationInterface, ERC165, Ownable {
      */
     function isDelegate(address addr) external view returns(bool) {
         return delegates[delegatesIndex[addr]] != address(0);
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address payable newOwner) public onlyOwner {
+        require(newOwner != address(0));
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
     }
 }

--- a/contracts/SegmentDirectory.sol
+++ b/contracts/SegmentDirectory.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.6;
 
 import "zos-lib/contracts/Initializable.sol";
+import "zos-lib/contracts/application/App.sol";
 import "openzeppelin-solidity/contracts/introspection/ERC165Checker.sol";
 import "./OrganizationInterface.sol";
 import "./Organization.sol";
@@ -10,6 +11,8 @@ import "./SegmentDirectoryEvents.sol";
  * An abstract SegmentDirectory that can handle a list of organizations
  */
 contract SegmentDirectory is Initializable, SegmentDirectoryEvents {
+    // ZeppelinOS App instance
+    App internal app;
 
     // Array of addresses of `Organization` contracts
     address[] public organizations;
@@ -45,9 +48,14 @@ contract SegmentDirectory is Initializable, SegmentDirectoryEvents {
      * @return {" ": "Address of the new organization."}
      */
     function createOrganization(string memory dataUri) internal returns (address) {
-        Organization newOrganization = new Organization(dataUri);
-        newOrganization.transferOwnership(msg.sender);
-        address newOrganizationAddress = address(newOrganization);
+        address newOrganizationAddress = address(
+            app.create(
+                "wt-contracts", 
+                "Organization", 
+                _owner, 
+                abi.encodeWithSignature("initialize(address,string)", msg.sender, dataUri)
+            )
+        );
         emit OrganizationCreated(newOrganizationAddress);
         return newOrganizationAddress;
     }
@@ -113,11 +121,13 @@ contract SegmentDirectory is Initializable, SegmentDirectoryEvents {
      * @dev Initializer for upgradeable contracts.
      * @param __owner The address of the contract owner
      * @param _lifToken The new contract address
+     * @param _app ZeppelinOS App address
      */
-    function initialize(address payable __owner, address _lifToken) public initializer {
+    function initialize(address payable __owner, address _lifToken, App _app) public initializer {
         require(__owner != address(0), 'Cannot set owner to 0x0 address');
         _owner = __owner;
         LifToken = _lifToken;
+        app = _app;
         organizations.length++;
     }
 

--- a/contracts/WindingTreeEntrypoint.sol
+++ b/contracts/WindingTreeEntrypoint.sol
@@ -44,6 +44,7 @@ contract WindingTreeEntrypoint is Initializable {
         LifToken = _lifToken;
         segments.length++;
     }
+    
     /**
      * @dev Throws if called by any account other than the owner.
      */

--- a/contracts/test/AirlineDirectoryUpgradeabilityTest.sol
+++ b/contracts/test/AirlineDirectoryUpgradeabilityTest.sol
@@ -1,13 +1,19 @@
 pragma solidity ^0.5.6;
 
 import "../AirlineDirectory.sol";
-import "./OrganizationUpgradeabilityTest.sol";
 
 contract AirlineDirectoryUpgradeabilityTest is AirlineDirectory {
-
+    
     function createAndAddAirline(string calldata dataUri) external returns (address) {
-        OrganizationUpgradeabilityTest newOrganization = new OrganizationUpgradeabilityTest(dataUri);
-        address newOrganizationAddress = address(newOrganization);
+        address newOrganizationAddress = address(
+            app.create(
+                "wt-contracts", 
+                "OrganizationUpgradeabilityTest", 
+                _owner, 
+                abi.encodeWithSignature("initialize(address,string)", msg.sender, dataUri)
+            )
+        );
+        emit OrganizationCreated(newOrganizationAddress);
         organizationsIndex[newOrganizationAddress] = organizations.length;
         organizations.push(newOrganizationAddress);
         emit OrganizationAdded(

--- a/contracts/test/HotelDirectoryUpgradeabilityTest.sol
+++ b/contracts/test/HotelDirectoryUpgradeabilityTest.sol
@@ -4,10 +4,17 @@ import "../HotelDirectory.sol";
 import "./OrganizationUpgradeabilityTest.sol";
 
 contract HotelDirectoryUpgradeabilityTest is HotelDirectory {
-
+    
     function createAndAddHotel(string calldata dataUri) external returns (address) {
-        OrganizationUpgradeabilityTest newOrganization = new OrganizationUpgradeabilityTest(dataUri);
-        address newOrganizationAddress = address(newOrganization);
+        address newOrganizationAddress = address(
+            app.create(
+                "wt-contracts", 
+                "OrganizationUpgradeabilityTest", 
+                _owner, 
+                abi.encodeWithSignature("initialize(address,string)", msg.sender, dataUri)
+            )
+        );
+        emit OrganizationCreated(newOrganizationAddress);
         organizationsIndex[newOrganizationAddress] = organizations.length;
         organizations.push(newOrganizationAddress);
         emit OrganizationAdded(

--- a/contracts/test/OrganizationUpgradeabilityTest.sol
+++ b/contracts/test/OrganizationUpgradeabilityTest.sol
@@ -4,10 +4,6 @@ import "../Organization.sol";
 
 contract OrganizationUpgradeabilityTest is Organization {
 
-    constructor(
-        string memory _dataUri
-    ) Organization(_dataUri) public {}
-
     function newFunction() public pure returns(uint) {
         return 100;
     }

--- a/contracts/test/OtaDirectoryUpgradeabilityTest.sol
+++ b/contracts/test/OtaDirectoryUpgradeabilityTest.sol
@@ -4,10 +4,17 @@ import "../OtaDirectory.sol";
 import "./OrganizationUpgradeabilityTest.sol";
 
 contract OtaDirectoryUpgradeabilityTest is OtaDirectory {
-
+    
     function createAndAddOta(string calldata dataUri) external returns (address) {
-        OrganizationUpgradeabilityTest newOrganization = new OrganizationUpgradeabilityTest(dataUri);
-        address newOrganizationAddress = address(newOrganization);
+        address newOrganizationAddress = address(
+            app.create(
+                "wt-contracts", 
+                "OrganizationUpgradeabilityTest", 
+                _owner, 
+                abi.encodeWithSignature("initialize(address,string)", msg.sender, dataUri)
+            )
+        );
+        emit OrganizationCreated(newOrganizationAddress);
         organizationsIndex[newOrganizationAddress] = organizations.length;
         organizations.push(newOrganizationAddress);
         emit OrganizationAdded(

--- a/docs/AirlineDirectory.md
+++ b/docs/AirlineDirectory.md
@@ -3,7 +3,6 @@
   * [organizationsByOwnerDeprecated](#function-organizationsbyownerdeprecated)
   * [addAirline](#function-addairline)
   * [airlines](#function-airlines)
-  * [initialize](#function-initialize)
   * [LifToken](#function-liftoken)
   * [createAndAddAirline](#function-createandaddairline)
   * [organizationsByOwnerIndexDeprecated](#function-organizationsbyownerindexdeprecated)
@@ -14,6 +13,7 @@
   * [removeAirline](#function-removeairline)
   * [createAirline](#function-createairline)
   * [getOrganizationsLength](#function-getorganizationslength)
+  * [initialize](#function-initialize)
   * [airlinesIndex](#function-airlinesindex)
   * [organizations](#function-organizations)
   * [setLifToken](#function-setliftoken)
@@ -88,20 +88,6 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* |  | undefined |
-
-## *function* initialize
-
-AirlineDirectory.initialize(__owner, _lifToken) `nonpayable` `485cc955`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The new contract address |
-
 
 ## *function* LifToken
 
@@ -234,6 +220,21 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* initialize
+
+AirlineDirectory.initialize(__owner, _lifToken, _app) `nonpayable` `c0c53b8b`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *address* | _lifToken | The new contract address |
+| *address* | _app | ZeppelinOS App address |
+
 
 ## *function* airlinesIndex
 

--- a/docs/AirlineDirectoryUpgradeabilityTest.md
+++ b/docs/AirlineDirectoryUpgradeabilityTest.md
@@ -4,7 +4,6 @@
   * [newFunction](#function-newfunction)
   * [addAirline](#function-addairline)
   * [airlines](#function-airlines)
-  * [initialize](#function-initialize)
   * [LifToken](#function-liftoken)
   * [createAndAddAirline](#function-createandaddairline)
   * [organizationsByOwnerIndexDeprecated](#function-organizationsbyownerindexdeprecated)
@@ -15,6 +14,7 @@
   * [removeAirline](#function-removeairline)
   * [createAirline](#function-createairline)
   * [getOrganizationsLength](#function-getorganizationslength)
+  * [initialize](#function-initialize)
   * [airlinesIndex](#function-airlinesindex)
   * [organizations](#function-organizations)
   * [setLifToken](#function-setliftoken)
@@ -97,20 +97,6 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* |  | undefined |
-
-## *function* initialize
-
-AirlineDirectoryUpgradeabilityTest.initialize(__owner, _lifToken) `nonpayable` `485cc955`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The new contract address |
-
 
 ## *function* LifToken
 
@@ -237,6 +223,21 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* initialize
+
+AirlineDirectoryUpgradeabilityTest.initialize(__owner, _lifToken, _app) `nonpayable` `c0c53b8b`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *address* | _lifToken | The new contract address |
+| *address* | _app | ZeppelinOS App address |
+
 
 ## *function* airlinesIndex
 

--- a/docs/HotelDirectory.md
+++ b/docs/HotelDirectory.md
@@ -2,7 +2,6 @@
   * [getHotels](#function-gethotels)
   * [organizationsByOwnerDeprecated](#function-organizationsbyownerdeprecated)
   * [removeHotel](#function-removehotel)
-  * [initialize](#function-initialize)
   * [addHotel](#function-addhotel)
   * [LifToken](#function-liftoken)
   * [organizationsByOwnerIndexDeprecated](#function-organizationsbyownerindexdeprecated)
@@ -13,6 +12,7 @@
   * [getOrganizations](#function-getorganizations)
   * [hotelsIndex](#function-hotelsindex)
   * [getOrganizationsLength](#function-getorganizationslength)
+  * [initialize](#function-initialize)
   * [getHotelsLength](#function-gethotelslength)
   * [hotels](#function-hotels)
   * [organizations](#function-organizations)
@@ -64,20 +64,6 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | hotel | Hotel's address |
-
-
-## *function* initialize
-
-HotelDirectory.initialize(__owner, _lifToken) `nonpayable` `485cc955`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The new contract address |
 
 
 ## *function* addHotel
@@ -220,6 +206,21 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* initialize
+
+HotelDirectory.initialize(__owner, _lifToken, _app) `nonpayable` `c0c53b8b`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *address* | _lifToken | The new contract address |
+| *address* | _app | ZeppelinOS App address |
+
 
 ## *function* getHotelsLength
 

--- a/docs/HotelDirectoryUpgradeabilityTest.md
+++ b/docs/HotelDirectoryUpgradeabilityTest.md
@@ -3,7 +3,6 @@
   * [organizationsByOwnerDeprecated](#function-organizationsbyownerdeprecated)
   * [newFunction](#function-newfunction)
   * [removeHotel](#function-removehotel)
-  * [initialize](#function-initialize)
   * [addHotel](#function-addhotel)
   * [LifToken](#function-liftoken)
   * [organizationsByOwnerIndexDeprecated](#function-organizationsbyownerindexdeprecated)
@@ -14,6 +13,7 @@
   * [getOrganizations](#function-getorganizations)
   * [hotelsIndex](#function-hotelsindex)
   * [getOrganizationsLength](#function-getorganizationslength)
+  * [initialize](#function-initialize)
   * [getHotelsLength](#function-gethotelslength)
   * [hotels](#function-hotels)
   * [organizations](#function-organizations)
@@ -73,20 +73,6 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | hotel | Hotel's address |
-
-
-## *function* initialize
-
-HotelDirectoryUpgradeabilityTest.initialize(__owner, _lifToken) `nonpayable` `485cc955`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The new contract address |
 
 
 ## *function* addHotel
@@ -223,6 +209,21 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* initialize
+
+HotelDirectoryUpgradeabilityTest.initialize(__owner, _lifToken, _app) `nonpayable` `c0c53b8b`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *address* | _lifToken | The new contract address |
+| *address* | _app | ZeppelinOS App address |
+
 
 ## *function* getHotelsLength
 

--- a/docs/Organization.md
+++ b/docs/Organization.md
@@ -5,14 +5,13 @@
   * [created](#function-created)
   * [getDataUri](#function-getdatauri)
   * [removeDelegate](#function-removedelegate)
-  * [renounceOwnership](#function-renounceownership)
   * [dataUri](#function-datauri)
   * [owner](#function-owner)
-  * [isOwner](#function-isowner)
   * [delegates](#function-delegates)
   * [delegatesIndex](#function-delegatesindex)
   * [addDelegate](#function-adddelegate)
   * [transferOwnership](#function-transferownership)
+  * [initialize](#function-initialize)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [DataUriChanged](#event-dataurichanged)
   * [DelegateAdded](#event-delegateadded)
@@ -100,15 +99,6 @@ Inputs
 | *address* | addr | Delegate's Ethereum address |
 
 
-## *function* renounceOwnership
-
-Organization.renounceOwnership() `nonpayable` `715018a6`
-
-> Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner.     * > Note: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner.
-
-
-
-
 ## *function* dataUri
 
 Organization.dataUri() `view` `8a9b29eb`
@@ -122,15 +112,6 @@ Organization.dataUri() `view` `8a9b29eb`
 Organization.owner() `view` `8da5cb5b`
 
 > Returns the address of the current owner.
-
-
-
-
-## *function* isOwner
-
-Organization.isOwner() `view` `8f32d59b`
-
-> Returns true if the caller is the current owner.
 
 
 
@@ -181,14 +162,27 @@ Outputs
 
 Organization.transferOwnership(newOwner) `nonpayable` `f2fde38b`
 
-> Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.
+> Allows the current owner to transfer control of the contract to a newOwner.
 
 Inputs
 
 | **type** | **name** | **description** |
 |-|-|-|
-| *address* | newOwner | undefined |
+| *address* | newOwner | The address to transfer ownership to. |
 
+
+## *function* initialize
+
+Organization.initialize(__owner, _dataUri) `nonpayable` `f399e22e`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *string* | _dataUri | pointer to Organization data |
 
 ## *event* OwnershipTransferred
 

--- a/docs/OrganizationUpgradeabilityTest.md
+++ b/docs/OrganizationUpgradeabilityTest.md
@@ -6,14 +6,13 @@
   * [created](#function-created)
   * [getDataUri](#function-getdatauri)
   * [removeDelegate](#function-removedelegate)
-  * [renounceOwnership](#function-renounceownership)
   * [dataUri](#function-datauri)
   * [owner](#function-owner)
-  * [isOwner](#function-isowner)
   * [delegates](#function-delegates)
   * [delegatesIndex](#function-delegatesindex)
   * [addDelegate](#function-adddelegate)
   * [transferOwnership](#function-transferownership)
+  * [initialize](#function-initialize)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [DataUriChanged](#event-dataurichanged)
   * [DelegateAdded](#event-delegateadded)
@@ -109,15 +108,6 @@ Inputs
 | *address* | addr | Delegate's Ethereum address |
 
 
-## *function* renounceOwnership
-
-OrganizationUpgradeabilityTest.renounceOwnership() `nonpayable` `715018a6`
-
-> Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner.     * > Note: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner.
-
-
-
-
 ## *function* dataUri
 
 OrganizationUpgradeabilityTest.dataUri() `view` `8a9b29eb`
@@ -131,15 +121,6 @@ OrganizationUpgradeabilityTest.dataUri() `view` `8a9b29eb`
 OrganizationUpgradeabilityTest.owner() `view` `8da5cb5b`
 
 > Returns the address of the current owner.
-
-
-
-
-## *function* isOwner
-
-OrganizationUpgradeabilityTest.isOwner() `view` `8f32d59b`
-
-> Returns true if the caller is the current owner.
 
 
 
@@ -190,14 +171,27 @@ Outputs
 
 OrganizationUpgradeabilityTest.transferOwnership(newOwner) `nonpayable` `f2fde38b`
 
-> Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.
+> Allows the current owner to transfer control of the contract to a newOwner.
 
 Inputs
 
 | **type** | **name** | **description** |
 |-|-|-|
-| *address* | newOwner | undefined |
+| *address* | newOwner | The address to transfer ownership to. |
 
+
+## *function* initialize
+
+OrganizationUpgradeabilityTest.initialize(__owner, _dataUri) `nonpayable` `f399e22e`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *string* | _dataUri | pointer to Organization data |
 
 ## *event* OwnershipTransferred
 

--- a/docs/OtaDirectory.md
+++ b/docs/OtaDirectory.md
@@ -3,7 +3,6 @@
   * [createAndAddOta](#function-createandaddota)
   * [createOta](#function-createota)
   * [otasIndex](#function-otasindex)
-  * [initialize](#function-initialize)
   * [LifToken](#function-liftoken)
   * [organizationsByOwnerIndexDeprecated](#function-organizationsbyownerindexdeprecated)
   * [getOtas](#function-getotas)
@@ -13,6 +12,7 @@
   * [getOrganizations](#function-getorganizations)
   * [otas](#function-otas)
   * [getOrganizationsLength](#function-getorganizationslength)
+  * [initialize](#function-initialize)
   * [getOtasLength](#function-getotaslength)
   * [removeOta](#function-removeota)
   * [organizations](#function-organizations)
@@ -92,20 +92,6 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
-
-## *function* initialize
-
-OtaDirectory.initialize(__owner, _lifToken) `nonpayable` `485cc955`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The new contract address |
-
 
 ## *function* LifToken
 
@@ -225,6 +211,21 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* initialize
+
+OtaDirectory.initialize(__owner, _lifToken, _app) `nonpayable` `c0c53b8b`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *address* | _lifToken | The new contract address |
+| *address* | _app | ZeppelinOS App address |
+
 
 ## *function* getOtasLength
 

--- a/docs/OtaDirectoryUpgradeabilityTest.md
+++ b/docs/OtaDirectoryUpgradeabilityTest.md
@@ -4,7 +4,6 @@
   * [newFunction](#function-newfunction)
   * [createOta](#function-createota)
   * [otasIndex](#function-otasindex)
-  * [initialize](#function-initialize)
   * [LifToken](#function-liftoken)
   * [organizationsByOwnerIndexDeprecated](#function-organizationsbyownerindexdeprecated)
   * [getOtas](#function-getotas)
@@ -14,6 +13,7 @@
   * [getOrganizations](#function-getorganizations)
   * [otas](#function-otas)
   * [getOrganizationsLength](#function-getorganizationslength)
+  * [initialize](#function-initialize)
   * [getOtasLength](#function-getotaslength)
   * [removeOta](#function-removeota)
   * [organizations](#function-organizations)
@@ -95,20 +95,6 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
-
-## *function* initialize
-
-OtaDirectoryUpgradeabilityTest.initialize(__owner, _lifToken) `nonpayable` `485cc955`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The new contract address |
-
 
 ## *function* LifToken
 
@@ -228,6 +214,21 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* initialize
+
+OtaDirectoryUpgradeabilityTest.initialize(__owner, _lifToken, _app) `nonpayable` `c0c53b8b`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *address* | _lifToken | The new contract address |
+| *address* | _app | ZeppelinOS App address |
+
 
 ## *function* getOtasLength
 

--- a/docs/SegmentDirectory.md
+++ b/docs/SegmentDirectory.md
@@ -1,12 +1,12 @@
 * [SegmentDirectory](#segmentdirectory)
   * [organizationsByOwnerDeprecated](#function-organizationsbyownerdeprecated)
-  * [initialize](#function-initialize)
   * [LifToken](#function-liftoken)
   * [organizationsByOwnerIndexDeprecated](#function-organizationsbyownerindexdeprecated)
   * [organizationsIndex](#function-organizationsindex)
   * [owner](#function-owner)
   * [getOrganizations](#function-getorganizations)
   * [getOrganizationsLength](#function-getorganizationslength)
+  * [initialize](#function-initialize)
   * [organizations](#function-organizations)
   * [setLifToken](#function-setliftoken)
   * [transferOwnership](#function-transferownership)
@@ -29,20 +29,6 @@ Inputs
 |-|-|-|
 | *address* |  | undefined |
 | *uint256* |  | undefined |
-
-
-## *function* initialize
-
-SegmentDirectory.initialize(__owner, _lifToken) `nonpayable` `485cc955`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The new contract address |
 
 
 ## *function* LifToken
@@ -113,6 +99,21 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* initialize
+
+SegmentDirectory.initialize(__owner, _lifToken, _app) `nonpayable` `c0c53b8b`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *address* | _lifToken | The new contract address |
+| *address* | _app | ZeppelinOS App address |
+
 
 ## *function* organizations
 

--- a/docs/TestSegmentDirectory.md
+++ b/docs/TestSegmentDirectory.md
@@ -1,12 +1,12 @@
 * [TestSegmentDirectory](#testsegmentdirectory)
   * [organizationsByOwnerDeprecated](#function-organizationsbyownerdeprecated)
-  * [initialize](#function-initialize)
   * [LifToken](#function-liftoken)
   * [organizationsByOwnerIndexDeprecated](#function-organizationsbyownerindexdeprecated)
   * [organizationsIndex](#function-organizationsindex)
   * [owner](#function-owner)
   * [getOrganizations](#function-getorganizations)
   * [getOrganizationsLength](#function-getorganizationslength)
+  * [initialize](#function-initialize)
   * [addFoodTruck](#function-addfoodtruck)
   * [removeFoodTruck](#function-removefoodtruck)
   * [organizations](#function-organizations)
@@ -33,20 +33,6 @@ Inputs
 |-|-|-|
 | *address* |  | undefined |
 | *uint256* |  | undefined |
-
-
-## *function* initialize
-
-TestSegmentDirectory.initialize(__owner, _lifToken) `nonpayable` `485cc955`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The new contract address |
 
 
 ## *function* LifToken
@@ -117,6 +103,21 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* initialize
+
+TestSegmentDirectory.initialize(__owner, _lifToken, _app) `nonpayable` `c0c53b8b`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *address* | _lifToken | The new contract address |
+| *address* | _app | ZeppelinOS App address |
+
 
 ## *function* addFoodTruck
 

--- a/test/airline-directory.js
+++ b/test/airline-directory.js
@@ -32,7 +32,7 @@ contract('AirlineDirectory', (accounts) => {
     airlineDirectoryProxy = await project.createProxy(AirlineDirectory, {
       from: proxyOwner,
       initFunction: 'initialize',
-      initArgs: [airlineDirectoryOwner, tokenAddress],
+      initArgs: [airlineDirectoryOwner, tokenAddress, project.app.address],
     });
     airlineDirectory = await AirlineDirectoryInterface.at(airlineDirectoryProxy.address);
   });
@@ -66,15 +66,12 @@ contract('AirlineDirectory', (accounts) => {
     it('should create airline', async () => {
       const address = await airlineDirectory.createAirline.call('dataUri', { from: airlineAccount });
       const receipt = await airlineDirectory.createAirline('dataUri', { from: airlineAccount });
-      assert.equal(receipt.logs.length, 3);
+      assert.equal(receipt.logs.length, 2);
       assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
       assert.equal(receipt.logs[0].args[0], help.zeroAddress);
-      assert.equal(receipt.logs[0].args[1], airlineDirectory.address);
-      assert.equal(receipt.logs[1].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[1].args[0], airlineDirectory.address);
-      assert.equal(receipt.logs[1].args[1], airlineAccount);
-      assert.equal(receipt.logs[2].event, 'OrganizationCreated');
-      assert.equal(receipt.logs[2].args.organization, address);
+      assert.equal(receipt.logs[0].args[1], airlineAccount);
+      assert.equal(receipt.logs[1].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[1].args.organization, address);
     });
   });
 
@@ -94,18 +91,15 @@ contract('AirlineDirectory', (accounts) => {
     it('should create and add airline', async () => {
       const address = await airlineDirectory.createAndAddAirline.call('dataUri', { from: airlineAccount });
       const receipt = await airlineDirectory.createAndAddAirline('dataUri', { from: airlineAccount });
-      assert.equal(receipt.logs.length, 4);
+      assert.equal(receipt.logs.length, 3);
       assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
       assert.equal(receipt.logs[0].args[0], help.zeroAddress);
-      assert.equal(receipt.logs[0].args[1], airlineDirectory.address);
-      assert.equal(receipt.logs[1].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[1].args[0], airlineDirectory.address);
-      assert.equal(receipt.logs[1].args[1], airlineAccount);
-      assert.equal(receipt.logs[2].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[0].args[1], airlineAccount);
+      assert.equal(receipt.logs[1].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[1].args.organization, address);
+      assert.equal(receipt.logs[2].event, 'OrganizationAdded');
       assert.equal(receipt.logs[2].args.organization, address);
-      assert.equal(receipt.logs[3].event, 'OrganizationAdded');
-      assert.equal(receipt.logs[3].args.organization, address);
-      assert.equal(receipt.logs[3].args.index, 1);
+      assert.equal(receipt.logs[2].args.index, 1);
     });
   });
 

--- a/test/airline-directory.js
+++ b/test/airline-directory.js
@@ -1,4 +1,4 @@
-const { TestHelper } = require('zos');
+const TestHelper = require('./helpers/zostest');
 const { Contracts, ZWeb3 } = require('zos-lib');
 const assert = require('chai').assert;
 const help = require('./helpers/index.js');

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -2,9 +2,9 @@ const misc = require('./misc');
 
 async function getOrganizationInfo (wtOrganization) {
   // Airline Info
-  const dataUri = await wtOrganization.getDataUri();
-  const owner = await wtOrganization.owner();
-  const created = await wtOrganization.created();
+  const dataUri = await wtOrganization.methods.getDataUri().call();
+  const owner = await wtOrganization.methods.owner().call();
+  const created = await wtOrganization.methods.created().call();
 
   return {
     dataUri: misc.isZeroString(dataUri) ? null : dataUri,

--- a/test/helpers/zostest.js
+++ b/test/helpers/zostest.js
@@ -1,0 +1,2 @@
+const { TestHelper, files: { ZosNetworkFile, ZosPackageFile } } = require('zos');
+module.exports = (fileName = 'zos.dev.json') => TestHelper({}, new ZosNetworkFile(new ZosPackageFile(fileName)));

--- a/test/hotel-directory.js
+++ b/test/hotel-directory.js
@@ -32,7 +32,7 @@ contract('HotelDirectory', (accounts) => {
     hotelDirectoryProxy = await project.createProxy(HotelDirectory, {
       from: proxyOwner,
       initFunction: 'initialize',
-      initArgs: [hotelDirectoryOwner, tokenAddress],
+      initArgs: [hotelDirectoryOwner, tokenAddress, project.app.address],
     });
     hotelDirectory = await HotelDirectoryInterface.at(hotelDirectoryProxy.address);
   });
@@ -66,15 +66,12 @@ contract('HotelDirectory', (accounts) => {
     it('should create hotel', async () => {
       const address = await hotelDirectory.createHotel.call('dataUri', { from: hotelAccount });
       const receipt = await hotelDirectory.createHotel('dataUri', { from: hotelAccount });
-      assert.equal(receipt.logs.length, 3);
+      assert.equal(receipt.logs.length, 2);
       assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
       assert.equal(receipt.logs[0].args[0], help.zeroAddress);
-      assert.equal(receipt.logs[0].args[1], hotelDirectory.address);
-      assert.equal(receipt.logs[1].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[1].args[0], hotelDirectory.address);
-      assert.equal(receipt.logs[1].args[1], hotelAccount);
-      assert.equal(receipt.logs[2].event, 'OrganizationCreated');
-      assert.equal(receipt.logs[2].args.organization, address);
+      assert.equal(receipt.logs[0].args[1], hotelAccount);
+      assert.equal(receipt.logs[1].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[1].args.organization, address);
     });
   });
 
@@ -94,18 +91,15 @@ contract('HotelDirectory', (accounts) => {
     it('should create and add hotel', async () => {
       const address = await hotelDirectory.createAndAddHotel.call('dataUri', { from: hotelAccount });
       const receipt = await hotelDirectory.createAndAddHotel('dataUri', { from: hotelAccount });
-      assert.equal(receipt.logs.length, 4);
+      assert.equal(receipt.logs.length, 3);
       assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
       assert.equal(receipt.logs[0].args[0], help.zeroAddress);
-      assert.equal(receipt.logs[0].args[1], hotelDirectory.address);
-      assert.equal(receipt.logs[1].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[1].args[0], hotelDirectory.address);
-      assert.equal(receipt.logs[1].args[1], hotelAccount);
-      assert.equal(receipt.logs[2].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[0].args[1], hotelAccount);
+      assert.equal(receipt.logs[1].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[1].args.organization, address);
+      assert.equal(receipt.logs[2].event, 'OrganizationAdded');
       assert.equal(receipt.logs[2].args.organization, address);
-      assert.equal(receipt.logs[3].event, 'OrganizationAdded');
-      assert.equal(receipt.logs[3].args.organization, address);
-      assert.equal(receipt.logs[3].args.index, 1);
+      assert.equal(receipt.logs[2].args.index, 1);
     });
   });
 

--- a/test/hotel-directory.js
+++ b/test/hotel-directory.js
@@ -1,4 +1,4 @@
-const { TestHelper } = require('zos');
+const TestHelper = require('./helpers/zostest');
 const { Contracts, ZWeb3 } = require('zos-lib');
 const assert = require('chai').assert;
 const help = require('./helpers/index.js');

--- a/test/organization.js
+++ b/test/organization.js
@@ -1,18 +1,35 @@
+const { TestHelper } = require('zos');
+const { Contracts, ZWeb3 } = require('zos-lib');
 const assert = require('chai').assert;
 const help = require('./helpers/index.js');
 
-const Organization = artifacts.require('Organization');
+ZWeb3.initialize(web3.currentProvider);
+// workaround for https://github.com/zeppelinos/zos/issues/704
+Contracts.setArtifactsDefaults({
+  gas: 60000000,
+});
+
+const Organization = Contracts.getFromLocal('Organization');
+const OrganizationUpgradeabilityTest = Contracts.getFromLocal('OrganizationUpgradeabilityTest');
 
 contract('Organization', (accounts) => {
   const organizationUri = 'bzz://something';
-  const organizationOwner = accounts[2];
+  const organizationOwner = accounts[1];
+  const proxyOwner = accounts[2];
   const nonOwnerAccount = accounts[3];
+
+  let organizationProxy;
   let organization;
+  let project;
 
   beforeEach(async () => {
-    organization = await Organization.new(organizationUri, {
-      from: organizationOwner,
+    project = await TestHelper();
+    organizationProxy = await project.createProxy(Organization, {
+      from: proxyOwner,
+      initFunction: 'initialize',
+      initArgs: [organizationOwner, organizationUri],
     });
+    organization = await Organization.at(organizationProxy.address);
   });
 
   describe('Constructor', () => {
@@ -25,13 +42,41 @@ contract('Organization', (accounts) => {
       assert.equal(info.dataUri, organizationUri);
     });
 
-    it('should throw with empty dataUri', async () => {
+    it('should throw with zero owner', async () => {
       try {
-        await Organization.new('', { from: organizationOwner });
+        const tProject = await TestHelper();
+        await tProject.createProxy(Organization, {
+          from: proxyOwner,
+          initFunction: 'initialize',
+          initArgs: ['0x0000000000000000000000000000000000000000', 'dataUri'],
+        });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
       }
+    });
+
+    it('should throw with empty dataUri', async () => {
+      try {
+        const tProject = await TestHelper();
+        await tProject.createProxy(Organization, {
+          from: proxyOwner,
+          initFunction: 'initialize',
+          initArgs: [organizationOwner, ''],
+        });
+        assert(false);
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+  });
+
+  describe('upgradeability', () => {
+    it('should upgrade Organisation and have new functions', async () => {
+      const upgradedOrganization = await OrganizationUpgradeabilityTest.new({ from: organizationOwner });
+      await project.proxyAdmin.upgradeProxy(organizationProxy.address, upgradedOrganization.address, OrganizationUpgradeabilityTest);
+      const newOrganization = await OrganizationUpgradeabilityTest.at(organizationProxy.address);
+      assert.equal(await newOrganization.methods.newFunction().call(), 100);
     });
   });
 
@@ -40,7 +85,7 @@ contract('Organization', (accounts) => {
 
     it('should not set empty dataUri', async () => {
       try {
-        await organization.changeDataUri('', { from: organizationOwner });
+        await organization.methods.changeDataUri('').send({ from: organizationOwner });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -48,14 +93,14 @@ contract('Organization', (accounts) => {
     });
 
     it('should set dataUri', async () => {
-      await organization.changeDataUri(newDataUri, { from: organizationOwner });
+      await organization.methods.changeDataUri(newDataUri).send({ from: organizationOwner });
       const info = await help.getOrganizationInfo(organization);
       assert.equal(info.dataUri, newDataUri);
     });
 
     it('should throw if not executed by organization owner', async () => {
       try {
-        await organization.changeDataUri(newDataUri, { from: nonOwnerAccount });
+        await organization.methods.changeDataUri(newDataUri).send({ from: nonOwnerAccount });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -65,18 +110,17 @@ contract('Organization', (accounts) => {
 
   describe('transferOwnership', () => {
     it('should transfer contract and emit OwnershipTransferred', async () => {
-      const receipt = await organization.transferOwnership(nonOwnerAccount, { from: organizationOwner });
-      assert.equal(receipt.logs.length, 1);
-      assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[0].args.previousOwner, organizationOwner);
-      assert.equal(receipt.logs[0].args.newOwner, nonOwnerAccount);
+      const receipt = await organization.methods.transferOwnership(nonOwnerAccount).send({ from: organizationOwner });
+      assert.equal(Object.keys(receipt.events).length, 1);
+      assert.equal(receipt.events.OwnershipTransferred.returnValues.previousOwner, organizationOwner);
+      assert.equal(receipt.events.OwnershipTransferred.returnValues.newOwner, nonOwnerAccount);
       const info = await help.getOrganizationInfo(organization);
       assert.equal(info.owner, nonOwnerAccount);
     });
 
     it('should throw if transferring to a zero address', async () => {
       try {
-        await organization.transferOwnership(help.zeroAddress, { from: organizationOwner });
+        await organization.methods.transferOwnership(help.zeroAddress).send({ from: organizationOwner });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -85,7 +129,7 @@ contract('Organization', (accounts) => {
 
     it('should throw if not executed from owner address', async () => {
       try {
-        await organization.transferOwnership(nonOwnerAccount, { from: nonOwnerAccount });
+        await organization.methods.transferOwnership(nonOwnerAccount).send({ from: nonOwnerAccount });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -95,20 +139,19 @@ contract('Organization', (accounts) => {
 
   describe('addDelegate', async () => {
     it('should add delegate and emit', async () => {
-      const receipt = await organization.addDelegate(nonOwnerAccount, { from: organizationOwner });
-      assert.equal(receipt.logs.length, 1);
-      assert.equal(receipt.logs[0].event, 'DelegateAdded');
-      assert.equal(receipt.logs[0].args.delegate, nonOwnerAccount);
-      assert.equal(receipt.logs[0].args.index, 1);
-      assert.equal(await organization.delegatesIndex(nonOwnerAccount), 1);
-      assert.equal(await organization.delegates(1), nonOwnerAccount);
-      assert.equal(await organization.isDelegate(nonOwnerAccount), true);
+      const receipt = await organization.methods.addDelegate(nonOwnerAccount).send({ from: organizationOwner });
+      assert.equal(Object.keys(receipt.events).length, 1);
+      assert.equal(receipt.events.DelegateAdded.returnValues.delegate, nonOwnerAccount);
+      assert.equal(receipt.events.DelegateAdded.returnValues.index, 1);
+      assert.equal(await organization.methods.delegatesIndex(nonOwnerAccount).call(), 1);
+      assert.equal(await organization.methods.delegates(1).call(), nonOwnerAccount);
+      assert.equal(await organization.methods.isDelegate(nonOwnerAccount).call(), true);
     });
 
     it('should throw when adding an existing delegate', async () => {
-      await organization.addDelegate(nonOwnerAccount, { from: organizationOwner });
+      await organization.methods.addDelegate(nonOwnerAccount).send({ from: organizationOwner });
       try {
-        await organization.addDelegate(nonOwnerAccount, { from: organizationOwner });
+        await organization.methods.addDelegate(nonOwnerAccount).send({ from: organizationOwner });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -117,7 +160,7 @@ contract('Organization', (accounts) => {
 
     it('should throw when adding a delegate with zero address', async () => {
       try {
-        await organization.addDelegate(help.zeroAddress, { from: organizationOwner });
+        await organization.methods.addDelegate(help.zeroAddress).send({ from: organizationOwner });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -126,7 +169,7 @@ contract('Organization', (accounts) => {
 
     it('should throw when adding a delegate by a non-owner', async () => {
       try {
-        await organization.addDelegate(nonOwnerAccount, { from: nonOwnerAccount });
+        await organization.methods.addDelegate(nonOwnerAccount).send({ from: nonOwnerAccount });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -136,19 +179,18 @@ contract('Organization', (accounts) => {
 
   describe('removeDelegate', async () => {
     it('should remove an existing delegate and emit', async () => {
-      await organization.addDelegate(nonOwnerAccount, { from: organizationOwner });
-      const receipt = await organization.removeDelegate(nonOwnerAccount, { from: organizationOwner });
-      assert.equal(receipt.logs.length, 1);
-      assert.equal(receipt.logs[0].event, 'DelegateRemoved');
-      assert.equal(receipt.logs[0].args.delegate, nonOwnerAccount);
-      assert.equal(await organization.isDelegate(nonOwnerAccount), false);
-      assert.equal(await organization.delegates(1), help.zeroAddress);
-      assert.equal(await organization.delegatesIndex(nonOwnerAccount), 0);
+      await organization.methods.addDelegate(nonOwnerAccount).send({ from: organizationOwner });
+      const receipt = await organization.methods.removeDelegate(nonOwnerAccount).send({ from: organizationOwner });
+      assert.equal(Object.keys(receipt.events).length, 1);
+      assert.equal(receipt.events.DelegateRemoved.returnValues.delegate, nonOwnerAccount);
+      assert.equal(await organization.methods.isDelegate(nonOwnerAccount).call(), false);
+      assert.equal(await organization.methods.delegates(1).call(), help.zeroAddress);
+      assert.equal(await organization.methods.delegatesIndex(nonOwnerAccount).call(), 0);
     });
 
     it('should throw when removing a non-existing delegate', async () => {
       try {
-        await organization.removeDelegate(nonOwnerAccount, { from: organizationOwner });
+        await organization.methods.removeDelegate(nonOwnerAccount).send({ from: organizationOwner });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -157,7 +199,7 @@ contract('Organization', (accounts) => {
 
     it('should throw when removing a zero address', async () => {
       try {
-        await organization.removeDelegate(help.zeroAddress, { from: organizationOwner });
+        await organization.methods.removeDelegate(help.zeroAddress).send({ from: organizationOwner });
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -167,12 +209,12 @@ contract('Organization', (accounts) => {
 
   describe('isDelegate', async () => {
     it('should return false for a non-delegate', async () => {
-      assert.equal(await organization.isDelegate(nonOwnerAccount), false);
+      assert.equal(await organization.methods.isDelegate(nonOwnerAccount).call(), false);
     });
 
     it('should return true for a delegate', async () => {
-      await organization.addDelegate(nonOwnerAccount, { from: organizationOwner });
-      assert.equal(await organization.isDelegate(nonOwnerAccount), true);
+      await organization.methods.addDelegate(nonOwnerAccount).send({ from: organizationOwner });
+      assert.equal(await organization.methods.isDelegate(nonOwnerAccount).call(), true);
     });
   });
 });

--- a/test/ota-directory.js
+++ b/test/ota-directory.js
@@ -32,7 +32,7 @@ contract('OtaDirectory', (accounts) => {
     otaDirectoryProxy = await project.createProxy(OtaDirectory, {
       from: proxyOwner,
       initFunction: 'initialize',
-      initArgs: [otaDirectoryOwner, tokenAddress],
+      initArgs: [otaDirectoryOwner, tokenAddress, project.app.address],
     });
     otaDirectory = await OtaDirectoryInterface.at(otaDirectoryProxy.address);
   });
@@ -66,15 +66,12 @@ contract('OtaDirectory', (accounts) => {
     it('should create ota', async () => {
       const address = await otaDirectory.createOta.call('dataUri', { from: otaAccount });
       const receipt = await otaDirectory.createOta('dataUri', { from: otaAccount });
-      assert.equal(receipt.logs.length, 3);
+      assert.equal(receipt.logs.length, 2);
       assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
       assert.equal(receipt.logs[0].args[0], help.zeroAddress);
-      assert.equal(receipt.logs[0].args[1], otaDirectory.address);
-      assert.equal(receipt.logs[1].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[1].args[0], otaDirectory.address);
-      assert.equal(receipt.logs[1].args[1], otaAccount);
-      assert.equal(receipt.logs[2].event, 'OrganizationCreated');
-      assert.equal(receipt.logs[2].args.organization, address);
+      assert.equal(receipt.logs[0].args[1], otaAccount);
+      assert.equal(receipt.logs[1].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[1].args.organization, address);
     });
   });
 
@@ -94,18 +91,15 @@ contract('OtaDirectory', (accounts) => {
     it('should create and add ota', async () => {
       const address = await otaDirectory.createAndAddOta.call('dataUri', { from: otaAccount });
       const receipt = await otaDirectory.createAndAddOta('dataUri', { from: otaAccount });
-      assert.equal(receipt.logs.length, 4);
+      assert.equal(receipt.logs.length, 3);
       assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
       assert.equal(receipt.logs[0].args[0], help.zeroAddress);
-      assert.equal(receipt.logs[0].args[1], otaDirectory.address);
-      assert.equal(receipt.logs[1].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[1].args[0], otaDirectory.address);
-      assert.equal(receipt.logs[1].args[1], otaAccount);
-      assert.equal(receipt.logs[2].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[0].args[1], otaAccount);
+      assert.equal(receipt.logs[1].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[1].args.organization, address);
+      assert.equal(receipt.logs[2].event, 'OrganizationAdded');
       assert.equal(receipt.logs[2].args.organization, address);
-      assert.equal(receipt.logs[3].event, 'OrganizationAdded');
-      assert.equal(receipt.logs[3].args.organization, address);
-      assert.equal(receipt.logs[3].args.index, 1);
+      assert.equal(receipt.logs[2].args.index, 1);
     });
   });
 

--- a/test/ota-directory.js
+++ b/test/ota-directory.js
@@ -1,4 +1,4 @@
-const { TestHelper } = require('zos');
+const TestHelper = require('./helpers/zostest');
 const { Contracts, ZWeb3 } = require('zos-lib');
 const assert = require('chai').assert;
 const help = require('./helpers/index.js');

--- a/test/segment-directory.js
+++ b/test/segment-directory.js
@@ -1,8 +1,17 @@
+const { TestHelper } = require('zos');
+const { Contracts, ZWeb3 } = require('zos-lib');
 const assert = require('chai').assert;
 const help = require('./helpers/index.js');
 
+ZWeb3.initialize(web3.currentProvider);
+// workaround for https://github.com/zeppelinos/zos/issues/704
+Contracts.setArtifactsDefaults({
+  gas: 60000000,
+});
+
+const Organization = Contracts.getFromLocal('Organization');
+
 const OrganizationInterface = artifacts.require('OrganizationInterface');
-const Organization = artifacts.require('Organization');
 const TestSegmentDirectory = artifacts.require('TestSegmentDirectory');
 const SegmentDirectory = artifacts.require('SegmentDirectory');
 const CustomOrganizationTest = artifacts.require('CustomOrganizationTest');
@@ -15,10 +24,12 @@ contract('TestSegmentDirectory', (accounts) => {
 
   let testSegmentDirectory;
   let segmentDirectory;
+  let project;
 
   beforeEach(async () => {
+    project = await TestHelper();
     testSegmentDirectory = await TestSegmentDirectory.new();
-    await testSegmentDirectory.initialize(segmentDirectoryOwner, tokenAddress);
+    await testSegmentDirectory.initialize(segmentDirectoryOwner, tokenAddress, project.app.address);
     segmentDirectory = await SegmentDirectory.at(testSegmentDirectory.address);
   });
 
@@ -26,7 +37,7 @@ contract('TestSegmentDirectory', (accounts) => {
     it('should not allow zero address owner', async () => {
       try {
         testSegmentDirectory = await TestSegmentDirectory.new();
-        await testSegmentDirectory.initialize(help.zeroAddress, tokenAddress);
+        await testSegmentDirectory.initialize(help.zeroAddress, tokenAddress, project.app.address);
         assert(false);
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
@@ -35,7 +46,7 @@ contract('TestSegmentDirectory', (accounts) => {
 
     it('should set liftoken', async () => {
       testSegmentDirectory = await TestSegmentDirectory.new();
-      await testSegmentDirectory.initialize(segmentDirectoryOwner, tokenAddress);
+      await testSegmentDirectory.initialize(segmentDirectoryOwner, tokenAddress, project.app.address);
       segmentDirectory = await SegmentDirectory.at(testSegmentDirectory.address);
       assert.equal(await segmentDirectory.LifToken(), tokenAddress);
     });
@@ -133,15 +144,12 @@ contract('TestSegmentDirectory', (accounts) => {
       const info = await help.getOrganizationInfo(organization);
       assert.equal(info.owner, foodTruckAccount);
       assert.equal(info.dataUri, 'dataUri');
-      assert.equal(receipt.logs.length, 3);
+      assert.equal(receipt.logs.length, 2);
       assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
       assert.equal(receipt.logs[0].args[0], help.zeroAddress);
-      assert.equal(receipt.logs[0].args[1], testSegmentDirectory.address);
-      assert.equal(receipt.logs[1].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[1].args[0], testSegmentDirectory.address);
-      assert.equal(receipt.logs[1].args[1], foodTruckAccount);
-      assert.equal(receipt.logs[2].event, 'OrganizationCreated');
-      assert.equal(receipt.logs[2].args.organization, address);
+      assert.equal(receipt.logs[0].args[1], foodTruckAccount);
+      assert.equal(receipt.logs[1].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[1].args.organization, address);
     });
 
     it('should not add the organization into any mapping', async () => {
@@ -161,9 +169,16 @@ contract('TestSegmentDirectory', (accounts) => {
   });
 
   describe('addFoodTruck', () => {
+    let organizationProxy;
     let organization;
+
     beforeEach(async () => {
-      organization = await Organization.new('dataUri', { from: foodTruckAccount });
+      organizationProxy = await project.createProxy(Organization, {
+        from: segmentDirectoryOwner,
+        initFunction: 'initialize',
+        initArgs: [foodTruckAccount, 'dataUri'],
+      });
+      organization = await Organization.at(organizationProxy.address);
     });
 
     it('should add the organization to the registry', async () => {
@@ -250,18 +265,15 @@ contract('TestSegmentDirectory', (accounts) => {
       const address = await testSegmentDirectory.createAndAddFoodTruck.call('dataUri', { from: foodTruckAccount });
       const receipt = await testSegmentDirectory.createAndAddFoodTruck('dataUri', { from: foodTruckAccount });
       const organization = await Organization.at(address);
-      assert.equal(receipt.logs.length, 4);
+      assert.equal(receipt.logs.length, 3);
       assert.equal(receipt.logs[0].event, 'OwnershipTransferred');
       assert.equal(receipt.logs[0].args[0], help.zeroAddress);
-      assert.equal(receipt.logs[0].args[1], testSegmentDirectory.address);
-      assert.equal(receipt.logs[1].event, 'OwnershipTransferred');
-      assert.equal(receipt.logs[1].args[0], testSegmentDirectory.address);
-      assert.equal(receipt.logs[1].args[1], foodTruckAccount);
-      assert.equal(receipt.logs[2].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[0].args[1], foodTruckAccount);
+      assert.equal(receipt.logs[1].event, 'OrganizationCreated');
+      assert.equal(receipt.logs[1].args.organization, organization.address);
+      assert.equal(receipt.logs[2].event, 'OrganizationAdded');
       assert.equal(receipt.logs[2].args.organization, organization.address);
-      assert.equal(receipt.logs[3].event, 'OrganizationAdded');
-      assert.equal(receipt.logs[3].args.organization, organization.address);
-      assert.equal(receipt.logs[3].args.index, 1);
+      assert.equal(receipt.logs[2].args.index, 1);
       const info = await help.getOrganizationInfo(organization);
       assert.equal(info.owner, foodTruckAccount);
       assert.equal(info.dataUri, 'dataUri');
@@ -308,7 +320,7 @@ contract('TestSegmentDirectory', (accounts) => {
 
     it('should throw if somebody is removing organization which she does not own', async () => {
       try {
-        await organization.transferOwnership(nonOwnerAccount, { from: foodTruckAccount });
+        await organization.methods.transferOwnership(nonOwnerAccount).send({ from: foodTruckAccount });
         await testSegmentDirectory.removeFoodTruck(organization.address, { from: foodTruckAccount });
         assert(false);
       } catch (e) {

--- a/zos.dev.json
+++ b/zos.dev.json
@@ -1,0 +1,23 @@
+{
+    "zosversion": "2.2",
+    "name": "wt-contracts",
+    "version": "0.6.1",
+    "publish": true,
+    "contracts": {
+      "HotelDirectory": "HotelDirectory",
+      "AirlineDirectory": "AirlineDirectory",
+      "OtaDirectory": "OtaDirectory",
+      "WindingTreeEntrypoint": "WindingTreeEntrypoint",
+      "PlaygroundEntrypoint": "WindingTreeEntrypoint",
+      "PlaygroundHotelDirectory": "HotelDirectory",
+      "PlaygroundAirlineDirectory": "AirlineDirectory",
+      "PlaygroundOtaDirectory": "OtaDirectory",
+      "DemoEntrypoint": "WindingTreeEntrypoint",
+      "DemoHotelDirectory": "HotelDirectory",
+      "DemoAirlineDirectory": "AirlineDirectory",
+      "DemoOtaDirectory": "OtaDirectory",
+      "Organization": "Organization",
+      "OrganizationUpgradeabilityTest": "OrganizationUpgradeabilityTest",
+      "AirlineDirectoryUpgradeabilityTest": "AirlineDirectoryUpgradeabilityTest"
+    }
+  }

--- a/zos.json
+++ b/zos.json
@@ -15,6 +15,9 @@
     "DemoEntrypoint": "WindingTreeEntrypoint",
     "DemoHotelDirectory": "HotelDirectory",
     "DemoAirlineDirectory": "AirlineDirectory",
-    "DemoOtaDirectory": "OtaDirectory"
+    "DemoOtaDirectory": "OtaDirectory",
+    "Organization": "Organization",
+    "OrganizationUpgradeabilityTest": "OrganizationUpgradeabilityTest",
+    "AirlineDirectoryUpgradeabilityTest": "AirlineDirectoryUpgradeabilityTest"
   }
 }

--- a/zos.json
+++ b/zos.json
@@ -16,8 +16,6 @@
     "DemoHotelDirectory": "HotelDirectory",
     "DemoAirlineDirectory": "AirlineDirectory",
     "DemoOtaDirectory": "OtaDirectory",
-    "Organization": "Organization",
-    "OrganizationUpgradeabilityTest": "OrganizationUpgradeabilityTest",
-    "AirlineDirectoryUpgradeabilityTest": "AirlineDirectoryUpgradeabilityTest"
+    "Organization": "Organization"
   }
 }


### PR DESCRIPTION
https://github.com/windingtree/wt-contracts/issues/218

- Organization is now upgradeable both ways:
    - As separately created
    - As created via SegmentDirectory.createOrganization
- Removed Organization constructor. All related logic is moved to the initialization function
- Changed the way SegmentDirectory is initialized (Zos app passed as the third parameter)
- Some tests (related to the Organization) are refactored to use zos-lib helpers