### PR TITLE
ORG.JSON hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Organization created in `OrganizationFactory` uses the
 [Upgradeability Proxy pattern](https://docs.zeppelinos.org). In short, the Factory owner will keep
 the ownership of the contract logic (proxy), whereas the transaction sender will keep the ownership of the
 data. Thus the Factory owner is responsible for the code. It is possible to transfer the proxy ownership
-to another account.
+to another account if need be.
 
 In any case, every Organization can have many *associated keys*. An *associated key* is an Ethereum address
 registered in the Organization that can operate on behalf of the organization. That means
@@ -60,6 +60,40 @@ If a signed message occurs somewhere in the platform, a content consumer might w
 if it was signed by an account associated with the declared Organization. That's when they would 
 first verify the signature and obtain an address of the signer. In the next step, they have to verify
 that the actual signer is registered as an `associatedKey` with the Organization by checking its smart contract.
+
+### Working with content hashes
+
+In order to reduce the attack surface, we require a hash of the off-chain stored data. We assume that it
+will not change very frequently, so updating the hash every-so-often won't add a significant cost to the whole operation.
+So, how does the hash actually look like? It is a `keccak256` (an Ethereum flavour of `sha3`) of the stringified ORG.JSON.
+Let's try an example:
+
+```js
+const web3utils = require('web3-utils');
+const stringOrgJsonContents = `{
+  "dataFormatVersion": "0.2.3",
+  "updatedAt": "2019-06-04T11:10:00.000Z",
+  "legalEntity": {
+    "name": "Acme Corp, Inc.",
+    "address": {
+      "road": "5th Avenue",
+      "houseNumber": "123",
+      "city": "New York",
+      "countryCode": "US"
+    },
+    "contact": {
+      "email": "ceo@acmecorpz.com"
+    }
+  }
+}`;
+// It is important to work with a textual ORG.JSON and *not* a JSON-parsed and re-serialized form.
+// JSON serializers might be producing different outcomes which would result in different hashes.
+const hashedOrgJson = web3utils.soliditySha3(stringOrgJsonContents);
+console.log(`Put me into 0xORG: ${hashedOrgJson}`);
+```
+
+You can also produce `keccak256` hashes in a myriad of other tools, such as
+[this one](https://emn178.github.io/online-tools/keccak_256.html).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ When a producer wants to participate, they have to do the following:
         1. Deploy the custom implementation.
     1. Assisted
         1. Locate Organization Factory address from Winding Tree Entrypoint
-        1. Call `create` method on the Organization Factory with the URI of off-chain data.
+        1. Call `create` method on the Organization Factory with the URI of off-chain data and a keccak256 hash of its contents.
         Organization smart contract that belongs to the transaction sender is created.
 1. Locate the appropriate Segment Directory address
 1. Add their newly created 0xORG to the segment directory by calling the `add` method
@@ -53,6 +53,8 @@ When a consumer wants to participate, they have to do the following:
 1. Call `getOrganizations` on the Segment Directory.
 1. Call `getOrgJsonUri` on every non-zero address returned as an instance of `OrganizationInterface` and crawl the off-chain data
 for more information.
+1. Call `getOrgJsonHash` on every non-zero address returned as an instance of `OrganizationInterface` and verify that the current 
+off-chain data contents hash matches the hash published in the smart contract.
 
 If a signed message occurs somewhere in the platform, a content consumer might want to decide
 if it was signed by an account associated with the declared Organization. That's when they would 
@@ -187,14 +189,14 @@ to play with this locally.
     ```
 These commands will return a network address where you can actually interact with the contracts.
 For a quick test, you can use the truffle console. We also need to use a different account than the
-owner of the `OrganizationFactory` to pose as the `Organization` owner
+owner of the `OrganizationFactory` to pose as the `Organization` owner.
 ```bash
 > ./node_modules/.bin/truffle console --network development
 truffle(development)> account = (await web3.eth.getAccounts())[1]
 truffle(development)> entrypoint = await WindingTreeEntrypoint.at('0x1B369F9fe2E2f6728Bf96487d0d7950c97417643')
 truffle(development)> entrypoint.setSegment('hotels', '0xde06f481353be1233d41f52bC215f337E7641976')
 truffle(development)> factory = await OrganizationFactory.at(await entrypoint.getOrganizationFactory({ from: account}))
-truffle(development)> factory.create('https://windingtree.com', { from: account })
+truffle(development)> factory.create('https://windingtree.com', '0xd1e15bcea4bbf5fa55e36bb5aa9ad5183a4acdc1b06a0f21f3dba8868dee2c99', { from: account })
 truffle(development)> factory.getCreatedOrganizations()
 truffle(development)> directory = await SegmentDirectory.at(await entrypoint.getSegment('hotels', { from: account}))
 truffle(development)> directory.getOrganizations()
@@ -204,4 +206,5 @@ truffle(development)> directory.getOrganizations()
   '0xa8c4cbB500da540D9fEd05BE7Bef0f0f5df3e2cc' ]
 truffle(development)> organization = await OrganizationInterface.at('0xa8c4cbB500da540D9fEd05BE7Bef0f0f5df3e2cc')
 truffle(development)> organization.getOrgJsonUri({ from: account })
+truffle(development)> organization.getOrgJsonHash({ from: account })
 ```

--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ via NPM (under the new version number). No data is lost.
 **How do I work with different organization versions on the client?**
 That should be possible by using an ABI of `OrganizationInterface` on the client side.
 
+### Contract upgrade process
+
+1. Run `npm version` and release on NPM. This will also bump the version in `zos.json` file.
+1. Deploy upgraded contracts with `./node_modules/.bin/zos push --network development` (use the network which you need).
+**The `Organization` implementation used by the Factory is changed in this step**.
+1. Upgrade contracts with `./node_modules/.bin/zos upgrade --network development` (use the network which you need). This
+will interactively ask you which contracts to upgrade. If you have changed the interface of Organization, make sure to
+upgrade `OrganizationFactory` as well.
+1. Upgrade Organization contracts with `node management/upgrade-organizations.js`. Make sure that its setup in a proper way.
+You can check the `Organization` implementation address in `zos.<network>.json` file. Also, use the account set as Organization
+Factory owner. Only that account can change Organizations' implementation.
+
 
 ### Local testing
 

--- a/contracts/AbstractOrganizationFactory.sol
+++ b/contracts/AbstractOrganizationFactory.sol
@@ -23,18 +23,24 @@ contract AbstractOrganizationFactory {
     /**
      * @dev Creates new 0xORG smart contract
      * @param  orgJsonUri Organization's data pointer
+     * @param  orgJsonHash Organization's data hash
      * @return {" ": "Address of the new organization."}
      */
-    function create(string calldata orgJsonUri) external returns (address);
+    function create(string calldata orgJsonUri, bytes32 orgJsonHash) external returns (address);
 
     /**
      * @dev Creates new 0xORG smart contract and adds it to a segment directory
      * in the same transaction
      * @param  orgJsonUri Organization's data pointer
+     * @param  orgJsonHash Organization's data hash
      * @param  directory Segment directory address
      * @return {" ": "Address of the new organization."}
      */
-    function createAndAddToDirectory(string calldata orgJsonUri, address directory) external returns (address);
+    function createAndAddToDirectory(
+        string calldata orgJsonUri,
+        bytes32 orgJsonHash,
+        address directory
+    ) external returns (address);
 
     /**
      * @dev Returns number of created organizations.

--- a/contracts/Organization.sol
+++ b/contracts/Organization.sol
@@ -83,9 +83,9 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
         _registerInterface(0x01ffc9a7);//_INTERFACE_ID_ERC165
         bytes4 associatedKeysInterface = i.hasAssociatedKey.selector ^ i.getAssociatedKeys.selector; // 0xfed71811
         bytes4 orgJsonInterface = i.getOrgJsonUri.selector ^ i.getOrgJsonHash.selector; // 0x6f4826be
-        _registerInterface(i.owner.selector);
         _registerInterface(orgJsonInterface);
         _registerInterface(associatedKeysInterface);
+        _registerInterface(i.owner.selector); // 0x8da5cb5b
         _registerInterface(
             i.owner.selector ^
             orgJsonInterface ^
@@ -207,5 +207,30 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
      */
     function owner() public view returns (address) {
         return _owner;
+    }
+
+
+    /**
+     * @dev A synchronization method that should be kept up to date with 
+     * the list of interfaces set during initialization. It should also be called
+     * everytime the implementation gets updated. If the interface list gets out of
+     * sync with the implementation at anytime, it is possible that some integrations
+     * will stop working. Since this method is not destructive, no access restriction
+     * is in place. It's supposed to be called by the proxy admin anyway.
+     */
+    function setInterfaces() public {
+        // OrganizationInterface i;
+        bytes4[5] memory interfaceIds = [
+            bytes4(0x01ffc9a7), // _INTERFACE_ID_ERC165
+            bytes4(0x8da5cb5b), // i.owner.selector
+            bytes4(0xfed71811), // i.hasAssociatedKey.selector ^ i.getAssociatedKeys.selector
+            bytes4(0x6f4826be), // i.getOrgJsonUri.selector ^ i.getOrgJsonHash.selector
+            bytes4(0x1c3af5f4)  // 0x8da5cb5b ^ 0xfed71811 ^ 0x6f4826be
+        ];
+        for (uint256 i = 0; i < interfaceIds.length; i++) {
+            if (!this.supportsInterface(interfaceIds[i])) {
+                _registerInterface(interfaceIds[i]);
+            }
+        }
     }
 }

--- a/contracts/Organization.sol
+++ b/contracts/Organization.sol
@@ -32,6 +32,12 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
     // organization.
     address[] public associatedKeys;
 
+    // keccak256 hash of the ORG.JSON file contents. This should
+    // be used to verify that the contents of ORG.JSON has not been tampered
+    // with. It is a responsibility of the Organization owner to keep this
+    // hash up to date.
+    bytes32 public orgJsonHash;
+
     /**
      * @dev Event triggered when owner of the organization is changed.
      */
@@ -41,6 +47,11 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
      * @dev Event triggered when orgJsonUri of the organization is changed.
      */
     event OrgJsonUriChanged(string previousOrgJsonUri, string newOrgJsonUri);
+
+    /**
+     * @dev Event triggered when orgJsonHash of the organization is changed.
+     */
+    event OrgJsonHashChanged(bytes32 indexed previousOrgJsonHash, bytes32 indexed newOrgJsonHash);
 
     /**
      * @dev Event triggered when new associatedKey is added.
@@ -100,6 +111,37 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
      */
     function getOrgJsonUri() external view returns (string memory) {
         return orgJsonUri;
+    }
+
+    /**
+     * @dev `changeOrgJsonHash` Allows owner to change Organization's orgJsonHash.
+     * @param  _orgJsonHash keccak256 hash of the new ORG.JSON contents.
+     */
+    function changeOrgJsonHash(bytes32 _orgJsonHash) public onlyOwner {
+        require(_orgJsonHash != 0, 'orgJsonHash cannot be empty');
+        emit OrgJsonHashChanged(orgJsonHash, _orgJsonHash);
+        orgJsonHash = _orgJsonHash;
+    }
+
+    /**
+     * @dev Returns keccak256 hash of raw ORG.JSON contents. This should
+     * be used to verify that the contents of ORG.JSON has not been tampered
+     * with. It is a responsibility of the Organization owner to keep this
+     * hash up to date.
+     * @return {" ": "Current ORG.JSON URI."}
+     */
+    function getOrgJsonHash() external view returns (bytes32) {
+        return orgJsonHash;
+    }
+
+    /**
+     * @dev Shorthand method to change ORG.JSON uri and hash at the same time
+     * @param  _orgJsonUri New orgJsonUri pointer of this Organization
+     * @param  _orgJsonHash keccak256 hash of the new ORG.JSON contents.
+     */
+    function changeOrgJsonUriAndHash(string memory _orgJsonUri, bytes32 _orgJsonHash) public onlyOwner {
+        changeOrgJsonUri(_orgJsonUri);
+        changeOrgJsonHash(_orgJsonHash);
     }
 
     /**

--- a/contracts/Organization.sol
+++ b/contracts/Organization.sol
@@ -81,13 +81,16 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
         associatedKeys.length++;
         OrganizationInterface i;
         _registerInterface(0x01ffc9a7);//_INTERFACE_ID_ERC165
+        bytes4 associatedKeysInterface = i.hasAssociatedKey.selector ^ i.getAssociatedKeys.selector; // 0xfed71811
+        bytes4 orgJsonInterface = i.getOrgJsonUri.selector ^ i.getOrgJsonHash.selector; // 0x6f4826be
+        _registerInterface(i.owner.selector);
+        _registerInterface(orgJsonInterface);
+        _registerInterface(associatedKeysInterface);
         _registerInterface(
             i.owner.selector ^
-            i.getOrgJsonUri.selector ^
-            i.getOrgJsonHash.selector ^
-            i.hasAssociatedKey.selector ^
-            i.getAssociatedKeys.selector
-        );
+            orgJsonInterface ^
+            associatedKeysInterface
+        ); // 0x1c3af5f4
     }
 
     /**

--- a/contracts/Organization.sol
+++ b/contracts/Organization.sol
@@ -84,6 +84,7 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
         _registerInterface(
             i.owner.selector ^
             i.getOrgJsonUri.selector ^
+            i.getOrgJsonHash.selector ^
             i.hasAssociatedKey.selector ^
             i.getAssociatedKeys.selector
         );

--- a/contracts/Organization.sol
+++ b/contracts/Organization.sol
@@ -67,13 +67,16 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
      * @dev Initializer for upgradeable contracts.
      * @param __owner The address of the contract owner
      * @param _orgJsonUri pointer to Organization data
+     * @param  _orgJsonHash keccak256 hash of the new ORG.JSON contents.
      */
-    function initialize(address payable __owner, string memory _orgJsonUri) public initializer {
+    function initialize(address payable __owner, string memory _orgJsonUri, bytes32 _orgJsonHash) public initializer {
         require(__owner != address(0), 'Cannot set owner to 0x0 address');
         require(bytes(_orgJsonUri).length != 0, 'orgJsonUri cannot be an empty string');
+        require(_orgJsonHash != 0, 'orgJsonHash cannot be empty');
         emit OwnershipTransferred(_owner, __owner);
         _owner = __owner;        
         orgJsonUri = _orgJsonUri;
+        orgJsonHash = _orgJsonHash;
         created = block.number;
         associatedKeys.length++;
         OrganizationInterface i;
@@ -99,8 +102,7 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
      * @param  _orgJsonUri New orgJsonUri pointer of this Organization
      */
     function changeOrgJsonUri(string memory _orgJsonUri) public onlyOwner {
-        bytes memory tempStringRepr = bytes(_orgJsonUri);
-        require(tempStringRepr.length != 0, 'orgJsonUri cannot be an empty string');
+        require(bytes(_orgJsonUri).length != 0, 'orgJsonUri cannot be an empty string');
         emit OrgJsonUriChanged(orgJsonUri, _orgJsonUri);
         orgJsonUri = _orgJsonUri;
     }
@@ -128,7 +130,7 @@ contract Organization is OrganizationInterface, ERC165, Initializable {
      * be used to verify that the contents of ORG.JSON has not been tampered
      * with. It is a responsibility of the Organization owner to keep this
      * hash up to date.
-     * @return {" ": "Current ORG.JSON URI."}
+     * @return {" ": "Current ORG.JSON hash."}
      */
     function getOrgJsonHash() external view returns (bytes32) {
         return orgJsonHash;

--- a/contracts/OrganizationFactory.sol
+++ b/contracts/OrganizationFactory.sol
@@ -40,15 +40,16 @@ contract OrganizationFactory is Initializable, AbstractOrganizationFactory {
      * 
      * Emits `OrganizationCreated` on success.
      * @param  orgJsonUri Organization's data pointer
+     * @param  orgJsonHash Organization's data hash
      * @return {" ": "Address of the new organization."}
      */
-    function createOrganization(string memory orgJsonUri) internal returns (address) {
+    function createOrganization(string memory orgJsonUri, bytes32 orgJsonHash) internal returns (address) {
         address newOrganizationAddress = address(
             app.create(
                 "wt-contracts", 
                 "Organization", 
                 _owner, 
-                abi.encodeWithSignature("initialize(address,string)", msg.sender, orgJsonUri)
+                abi.encodeWithSignature("initialize(address,string,bytes32)", msg.sender, orgJsonUri, orgJsonHash)
             )
         );
         emit OrganizationCreated(newOrganizationAddress);
@@ -60,10 +61,11 @@ contract OrganizationFactory is Initializable, AbstractOrganizationFactory {
     /**
      * @dev `create` proxies and externalizes createOrganization
      * @param  orgJsonUri Organization's data pointer
+     * @param  orgJsonHash Organization's data hash
      * @return {" ": "Address of the new organization."}
      */
-    function create(string calldata orgJsonUri) external returns (address) {
-        return createOrganization(orgJsonUri);
+    function create(string calldata orgJsonUri, bytes32 orgJsonHash) external returns (address) {
+        return createOrganization(orgJsonUri, orgJsonHash);
     }
 
     /**
@@ -73,10 +75,15 @@ contract OrganizationFactory is Initializable, AbstractOrganizationFactory {
      * We cannot reuse create call due to the Organization ownership restrictions.
      * 
      * @param  orgJsonUri Organization's data pointer
+     * @param  orgJsonHash Organization's data hash
      * @param  directory Segment directory's address
      * @return {" ": "Address of the new organization."}
      */
-    function createAndAddToDirectory(string calldata orgJsonUri, address directory) external returns (address) {
+    function createAndAddToDirectory(
+        string calldata orgJsonUri,
+        bytes32 orgJsonHash,
+        address directory
+    ) external returns (address) {
         // TODO rewrite so that directory address gets known from entrypoint #248
         require(directory != address(0), 'Cannot use directory with 0x0 address');
         address newOrganizationAddress = address(
@@ -84,7 +91,7 @@ contract OrganizationFactory is Initializable, AbstractOrganizationFactory {
                 "wt-contracts", 
                 "Organization", 
                 _owner, 
-                abi.encodeWithSignature("initialize(address,string)", address(this), orgJsonUri)
+                abi.encodeWithSignature("initialize(address,string,bytes32)", address(this), orgJsonUri, orgJsonHash)
             )
         );
         AbstractSegmentDirectory sd = AbstractSegmentDirectory(directory);

--- a/contracts/OrganizationInterface.sol
+++ b/contracts/OrganizationInterface.sol
@@ -33,7 +33,7 @@ contract OrganizationInterface is IERC165 {
      * be used to verify that the contents of ORG.JSON has not been tampered
      * with. It is a responsibility of the Organization owner to keep this
      * hash up to date.
-     * @return {" ": "Current ORG.JSON URI."}
+     * @return {" ": "Current ORG.JSON hash."}
      */
     function getOrgJsonHash() external view returns (bytes32);
 

--- a/contracts/OrganizationInterface.sol
+++ b/contracts/OrganizationInterface.sol
@@ -29,6 +29,15 @@ contract OrganizationInterface is IERC165 {
     function getOrgJsonUri() external view returns (string memory);
 
     /**
+     * @dev Returns keccak256 hash of raw ORG.JSON contents. This should
+     * be used to verify that the contents of ORG.JSON has not been tampered
+     * with. It is a responsibility of the Organization owner to keep this
+     * hash up to date.
+     * @return {" ": "Current ORG.JSON URI."}
+     */
+    function getOrgJsonHash() external view returns (bytes32);
+
+    /**
      * @dev Returns if an `address` is associated with the Organization.
      * Associated keys can be used on behalf of the organization,
      * typically to sign messages.

--- a/contracts/SegmentDirectory.sol
+++ b/contracts/SegmentDirectory.sol
@@ -41,8 +41,9 @@ contract SegmentDirectory is Initializable, AbstractSegmentDirectory {
      * @return {" ": "Address of the organization."}
      */
     function addOrganization(address organization) internal returns (address) {
-        // this is intentionally not part of the state variables as we expect it to change in time.
         require(_organizationsIndex[organization] == 0, 'Cannot add organization twice');
+        // This is intentionally not part of the state variables as we expect it to change in time.
+        // It should always be the latest xor of *all* methods in the OrganizationInterface.
         bytes4 _INTERFACE_ID_ORGANIZATION = 0x1c3af5f4;
         require(
             ERC165Checker._supportsInterface(organization, _INTERFACE_ID_ORGANIZATION),

--- a/contracts/SegmentDirectory.sol
+++ b/contracts/SegmentDirectory.sol
@@ -43,7 +43,7 @@ contract SegmentDirectory is Initializable, AbstractSegmentDirectory {
     function addOrganization(address organization) internal returns (address) {
         // this is intentionally not part of the state variables as we expect it to change in time.
         require(_organizationsIndex[organization] == 0, 'Cannot add organization twice');
-        bytes4 _INTERFACE_ID_ORGANIZATION = 0x6ef78a3d;
+        bytes4 _INTERFACE_ID_ORGANIZATION = 0x1c3af5f4;
         require(
             ERC165Checker._supportsInterface(organization, _INTERFACE_ID_ORGANIZATION),
             'Organization has to support _INTERFACE_ID_ORGANIZATION'

--- a/contracts/test/CustomOrganizationTest.sol
+++ b/contracts/test/CustomOrganizationTest.sol
@@ -13,6 +13,7 @@ contract CustomOrganizationTest is ERC165, OrganizationInterface {
         _registerInterface(
             i.owner.selector ^
             i.getOrgJsonUri.selector ^
+            i.getOrgJsonHash.selector ^
             i.hasAssociatedKey.selector ^
             i.getAssociatedKeys.selector
         );

--- a/contracts/test/CustomOrganizationTest.sol
+++ b/contracts/test/CustomOrganizationTest.sol
@@ -8,15 +8,12 @@ contract CustomOrganizationTest is ERC165, OrganizationInterface {
     address[] associatedKeys;
 
     constructor() public {
-        OrganizationInterface i;
         _owner = msg.sender;
-        _registerInterface(
-            i.owner.selector ^
-            i.getOrgJsonUri.selector ^
-            i.getOrgJsonHash.selector ^
-            i.hasAssociatedKey.selector ^
-            i.getAssociatedKeys.selector
-        );
+        _registerInterface(bytes4(0x01ffc9a7)); // _INTERFACE_ID_ERC165
+        _registerInterface(bytes4(0x8da5cb5b)); // i.owner.selector
+        _registerInterface(bytes4(0xfed71811)); // i.hasAssociatedKey.selector ^ i.getAssociatedKeys.selector
+        _registerInterface(bytes4(0x6f4826be)); // i.getOrgJsonUri.selector ^ i.getOrgJsonHash.selector
+        _registerInterface(bytes4(0x1c3af5f4)); // 0x8da5cb5b ^ 0xfed71811 ^ 0x6f4826be
     }
 
     function owner() public view returns (address) {

--- a/contracts/test/CustomOrganizationTest.sol
+++ b/contracts/test/CustomOrganizationTest.sol
@@ -26,6 +26,10 @@ contract CustomOrganizationTest is ERC165, OrganizationInterface {
         return "https://super-sweet-custom-organization.com";
     }
 
+    function getOrgJsonHash() external view returns (bytes32) {
+        return 0xd1e15bcea4bbf5fa55e36bb5aa9ad5183a4acdc1b06a0f21f3dba8868dee2c99;
+    }
+
     function hasAssociatedKey(address addr) external view returns(bool) {
         return addr == _owner;
     }

--- a/contracts/test/OrganizationFactoryUpgradeabilityTest.sol
+++ b/contracts/test/OrganizationFactoryUpgradeabilityTest.sol
@@ -4,13 +4,13 @@ import "../OrganizationFactory.sol";
 
 contract OrganizationFactoryUpgradeabilityTest is OrganizationFactory {
     
-    function create(string calldata orgJsonUri) external returns (address) {
+    function create(string calldata orgJsonUri, bytes32 orgJsonHash) external returns (address) {
         address newOrganizationAddress = address(
             app.create(
                 "wt-contracts", 
                 "OrganizationUpgradeabilityTest", 
                 _owner, 
-                abi.encodeWithSignature("initialize(address,string)", msg.sender, orgJsonUri)
+                abi.encodeWithSignature("initialize(address,string,bytes32)", msg.sender, orgJsonUri, orgJsonHash)
             )
         );
         _createdOrganizationsIndex[newOrganizationAddress] = _createdOrganizations.length;

--- a/contracts/test/OrganizationUpgradeabilityTest.sol
+++ b/contracts/test/OrganizationUpgradeabilityTest.sol
@@ -8,4 +8,21 @@ contract OrganizationUpgradeabilityTest is Organization {
         return 100;
     }
 
+    function setInterfaces() public {
+        // OrganizationInterface i;
+        bytes4[6] memory interfaceIds = [
+            bytes4(0x01ffc9a7), // _INTERFACE_ID_ERC165
+            bytes4(0x8da5cb5b), // i.owner.selector
+            bytes4(0xfed71811), // i.hasAssociatedKey.selector ^ i.getAssociatedKeys.selector
+            bytes4(0x6f4826be), // i.getOrgJsonUri.selector ^ i.getOrgJsonHash.selector
+            bytes4(0x1c3af5f4),  // 0x8da5cb5b ^ 0xfed71811 ^ 0x6f4826be
+            this.newFunction.selector
+        ];
+        for (uint256 i = 0; i < interfaceIds.length; i++) {
+            if (!this.supportsInterface(interfaceIds[i])) {
+                _registerInterface(interfaceIds[i]);
+            }
+        }
+    }
+
 }

--- a/docs/AbstractOrganizationFactory.md
+++ b/docs/AbstractOrganizationFactory.md
@@ -1,11 +1,11 @@
 * [AbstractOrganizationFactory](#abstractorganizationfactory)
   * [createdOrganizationsIndex](#function-createdorganizationsindex)
-  * [createAndAddToDirectory](#function-createandaddtodirectory)
   * [getCreatedOrganizations](#function-getcreatedorganizations)
   * [getCreatedOrganizationsLength](#function-getcreatedorganizationslength)
+  * [create](#function-create)
   * [owner](#function-owner)
   * [createdOrganizations](#function-createdorganizations)
-  * [create](#function-create)
+  * [createAndAddToDirectory](#function-createandaddtodirectory)
   * [OrganizationCreated](#event-organizationcreated)
   * [OwnershipTransferred](#event-ownershiptransferred)
 
@@ -25,25 +25,6 @@ Inputs
 | *address* | organization | undefined |
 
 
-## *function* createAndAddToDirectory
-
-AbstractOrganizationFactory.createAndAddToDirectory(orgJsonUri, directory) `nonpayable` `1f7d8864`
-
-> Creates new 0xORG smart contract and adds it to a segment directory in the same transaction
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *string* | orgJsonUri | Organization's data pointer |
-| *address* | directory | Segment directory address |
-
-Outputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* |  | undefined |
-
 ## *function* getCreatedOrganizations
 
 AbstractOrganizationFactory.getCreatedOrganizations() `view` `270ca0f0`
@@ -61,6 +42,25 @@ AbstractOrganizationFactory.getCreatedOrganizationsLength() `view` `3db297e9`
 
 
 
+
+## *function* create
+
+AbstractOrganizationFactory.create(orgJsonUri, orgJsonHash) `nonpayable` `3dee0c50`
+
+> Creates new 0xORG smart contract
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | orgJsonUri | Organization's data pointer |
+| *bytes32* | orgJsonHash | Organization's data hash |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
 
 ## *function* owner
 
@@ -84,17 +84,19 @@ Inputs
 | *uint256* | index | undefined |
 
 
-## *function* create
+## *function* createAndAddToDirectory
 
-AbstractOrganizationFactory.create(orgJsonUri) `nonpayable` `b6a46b3b`
+AbstractOrganizationFactory.createAndAddToDirectory(orgJsonUri, orgJsonHash, directory) `nonpayable` `af276209`
 
-> Creates new 0xORG smart contract
+> Creates new 0xORG smart contract and adds it to a segment directory in the same transaction
 
 Inputs
 
 | **type** | **name** | **description** |
 |-|-|-|
 | *string* | orgJsonUri | Organization's data pointer |
+| *bytes32* | orgJsonHash | Organization's data hash |
+| *address* | directory | Segment directory address |
 
 Outputs
 

--- a/docs/CustomOrganizationTest.md
+++ b/docs/CustomOrganizationTest.md
@@ -2,6 +2,7 @@
   * [supportsInterface](#function-supportsinterface)
   * [getAssociatedKeys](#function-getassociatedkeys)
   * [getOrgJsonUri](#function-getorgjsonuri)
+  * [getOrgJsonHash](#function-getorgjsonhash)
   * [owner](#function-owner)
   * [hasAssociatedKey](#function-hasassociatedkey)
 
@@ -32,6 +33,14 @@ CustomOrganizationTest.getAssociatedKeys() `view` `0ba11d86`
 ## *function* getOrgJsonUri
 
 CustomOrganizationTest.getOrgJsonUri() `view` `1d855977`
+
+
+
+
+
+## *function* getOrgJsonHash
+
+CustomOrganizationTest.getOrgJsonHash() `view` `72cd7fc9`
 
 
 

--- a/docs/Organization.md
+++ b/docs/Organization.md
@@ -17,6 +17,7 @@
   * [associatedKeysIndex](#function-associatedkeysindex)
   * [transferOwnership](#function-transferownership)
   * [hasAssociatedKey](#function-hasassociatedkey)
+  * [setInterfaces](#function-setinterfaces)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [OrgJsonUriChanged](#event-orgjsonurichanged)
   * [OrgJsonHashChanged](#event-orgjsonhashchanged)
@@ -254,6 +255,15 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *bool* |  | undefined |
+
+## *function* setInterfaces
+
+Organization.setInterfaces() `nonpayable` `fca85eb3`
+
+> A synchronization method that should be kept up to date with  the list of interfaces set during initialization. It should also be called everytime the implementation gets updated. If the interface list gets out of sync with the implementation at anytime, it is possible that some integrations will stop working. Since this method is not destructive, no access restriction is in place. It's supposed to be called by the proxy admin anyway.
+
+
+
 ## *event* OwnershipTransferred
 
 Organization.OwnershipTransferred(previousOwner, newOwner) `8be0079c`

--- a/docs/Organization.md
+++ b/docs/Organization.md
@@ -4,17 +4,22 @@
   * [getAssociatedKeys](#function-getassociatedkeys)
   * [associatedKeys](#function-associatedkeys)
   * [getOrgJsonUri](#function-getorgjsonuri)
+  * [orgJsonHash](#function-orgjsonhash)
   * [created](#function-created)
+  * [changeOrgJsonHash](#function-changeorgjsonhash)
   * [orgJsonUri](#function-orgjsonuri)
+  * [getOrgJsonHash](#function-getorgjsonhash)
   * [addAssociatedKey](#function-addassociatedkey)
   * [owner](#function-owner)
+  * [changeOrgJsonUriAndHash](#function-changeorgjsonuriandhash)
   * [changeOrgJsonUri](#function-changeorgjsonuri)
+  * [initialize](#function-initialize)
   * [associatedKeysIndex](#function-associatedkeysindex)
   * [transferOwnership](#function-transferownership)
-  * [initialize](#function-initialize)
   * [hasAssociatedKey](#function-hasassociatedkey)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [OrgJsonUriChanged](#event-orgjsonurichanged)
+  * [OrgJsonHashChanged](#event-orgjsonhashchanged)
   * [AssociatedKeyAdded](#event-associatedkeyadded)
   * [AssociatedKeyRemoved](#event-associatedkeyremoved)
 
@@ -87,12 +92,33 @@ Outputs
 |-|-|-|
 | *string* |  | undefined |
 
+## *function* orgJsonHash
+
+Organization.orgJsonHash() `view` `2095005b`
+
+
+
+
+
 ## *function* created
 
 Organization.created() `view` `325a19f1`
 
 
 
+
+
+## *function* changeOrgJsonHash
+
+Organization.changeOrgJsonHash(_orgJsonHash) `nonpayable` `32fda029`
+
+> `changeOrgJsonHash` Allows owner to change Organization's orgJsonHash.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | _orgJsonHash | keccak256 hash of the new ORG.JSON contents. |
 
 
 ## *function* orgJsonUri
@@ -102,6 +128,20 @@ Organization.orgJsonUri() `view` `3b3ba578`
 
 
 
+
+## *function* getOrgJsonHash
+
+Organization.getOrgJsonHash() `view` `72cd7fc9`
+
+> Returns keccak256 hash of raw ORG.JSON contents. This should be used to verify that the contents of ORG.JSON has not been tampered with. It is a responsibility of the Organization owner to keep this hash up to date.
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
 
 ## *function* addAssociatedKey
 
@@ -130,6 +170,20 @@ Organization.owner() `view` `8da5cb5b`
 
 
 
+## *function* changeOrgJsonUriAndHash
+
+Organization.changeOrgJsonUriAndHash(_orgJsonUri, _orgJsonHash) `nonpayable` `a4e99359`
+
+> Shorthand method to change ORG.JSON uri and hash at the same time
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _orgJsonUri | New orgJsonUri pointer of this Organization |
+| *bytes32* | _orgJsonHash | keccak256 hash of the new ORG.JSON contents. |
+
+
 ## *function* changeOrgJsonUri
 
 Organization.changeOrgJsonUri(_orgJsonUri) `nonpayable` `b454f4ef`
@@ -141,6 +195,21 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *string* | _orgJsonUri | New orgJsonUri pointer of this Organization |
+
+
+## *function* initialize
+
+Organization.initialize(__owner, _orgJsonUri, _orgJsonHash) `nonpayable` `ca303fc7`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *string* | _orgJsonUri | pointer to Organization data |
+| *bytes32* | _orgJsonHash | keccak256 hash of the new ORG.JSON contents. |
 
 
 ## *function* associatedKeysIndex
@@ -166,20 +235,6 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | newOwner | The address to transfer ownership to. |
-
-
-## *function* initialize
-
-Organization.initialize(__owner, _orgJsonUri) `nonpayable` `f399e22e`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *string* | _orgJsonUri | pointer to Organization data |
 
 
 ## *function* hasAssociatedKey
@@ -218,8 +273,19 @@ Arguments
 
 | **type** | **name** | **description** |
 |-|-|-|
-| *string* | previousOrgJsonUri | indexed |
-| *string* | newOrgJsonUri | indexed |
+| *string* | previousOrgJsonUri | not indexed |
+| *string* | newOrgJsonUri | not indexed |
+
+## *event* OrgJsonHashChanged
+
+Organization.OrgJsonHashChanged(previousOrgJsonHash, newOrgJsonHash) `ccd34c96`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | previousOrgJsonHash | indexed |
+| *bytes32* | newOrgJsonHash | indexed |
 
 ## *event* AssociatedKeyAdded
 

--- a/docs/OrganizationFactory.md
+++ b/docs/OrganizationFactory.md
@@ -1,12 +1,12 @@
 * [OrganizationFactory](#organizationfactory)
   * [createdOrganizationsIndex](#function-createdorganizationsindex)
-  * [createAndAddToDirectory](#function-createandaddtodirectory)
   * [getCreatedOrganizations](#function-getcreatedorganizations)
   * [getCreatedOrganizationsLength](#function-getcreatedorganizationslength)
+  * [create](#function-create)
   * [initialize](#function-initialize)
   * [owner](#function-owner)
   * [createdOrganizations](#function-createdorganizations)
-  * [create](#function-create)
+  * [createAndAddToDirectory](#function-createandaddtodirectory)
   * [transferOwnership](#function-transferownership)
   * [OrganizationCreated](#event-organizationcreated)
   * [OwnershipTransferred](#event-ownershiptransferred)
@@ -31,25 +31,6 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
-
-## *function* createAndAddToDirectory
-
-OrganizationFactory.createAndAddToDirectory(orgJsonUri, directory) `nonpayable` `1f7d8864`
-
-> `createAndAddToDirectory` Creates the organization contract and tries to add it to a SegmentDirectory living on the passed `directory` address.     * We cannot reuse create call due to the Organization ownership restrictions. 
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *string* | orgJsonUri | Organization's data pointer |
-| *address* | directory | Segment directory's address |
-
-Outputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* |  | undefined |
 
 ## *function* getCreatedOrganizations
 
@@ -78,6 +59,25 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* create
+
+OrganizationFactory.create(orgJsonUri, orgJsonHash) `nonpayable` `3dee0c50`
+
+> `create` proxies and externalizes createOrganization
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | orgJsonUri | Organization's data pointer |
+| *bytes32* | orgJsonHash | Organization's data hash |
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
 
 ## *function* initialize
 
@@ -120,17 +120,19 @@ Outputs
 |-|-|-|
 | *address* |  | undefined |
 
-## *function* create
+## *function* createAndAddToDirectory
 
-OrganizationFactory.create(orgJsonUri) `nonpayable` `b6a46b3b`
+OrganizationFactory.createAndAddToDirectory(orgJsonUri, orgJsonHash, directory) `nonpayable` `af276209`
 
-> `create` proxies and externalizes createOrganization
+> `createAndAddToDirectory` Creates the organization contract and tries to add it to a SegmentDirectory living on the passed `directory` address.     * We cannot reuse create call due to the Organization ownership restrictions. 
 
 Inputs
 
 | **type** | **name** | **description** |
 |-|-|-|
 | *string* | orgJsonUri | Organization's data pointer |
+| *bytes32* | orgJsonHash | Organization's data hash |
+| *address* | directory | Segment directory's address |
 
 Outputs
 

--- a/docs/OrganizationFactoryUpgradeabilityTest.md
+++ b/docs/OrganizationFactoryUpgradeabilityTest.md
@@ -1,13 +1,13 @@
 * [OrganizationFactoryUpgradeabilityTest](#organizationfactoryupgradeabilitytest)
   * [createdOrganizationsIndex](#function-createdorganizationsindex)
   * [newFunction](#function-newfunction)
-  * [createAndAddToDirectory](#function-createandaddtodirectory)
   * [getCreatedOrganizations](#function-getcreatedorganizations)
   * [getCreatedOrganizationsLength](#function-getcreatedorganizationslength)
+  * [create](#function-create)
   * [initialize](#function-initialize)
   * [owner](#function-owner)
   * [createdOrganizations](#function-createdorganizations)
-  * [create](#function-create)
+  * [createAndAddToDirectory](#function-createandaddtodirectory)
   * [transferOwnership](#function-transferownership)
   * [OrganizationCreated](#event-organizationcreated)
   * [OwnershipTransferred](#event-ownershiptransferred)
@@ -41,25 +41,6 @@ OrganizationFactoryUpgradeabilityTest.newFunction() `pure` `1b28d63e`
 
 
 
-## *function* createAndAddToDirectory
-
-OrganizationFactoryUpgradeabilityTest.createAndAddToDirectory(orgJsonUri, directory) `nonpayable` `1f7d8864`
-
-> `createAndAddToDirectory` Creates the organization contract and tries to add it to a SegmentDirectory living on the passed `directory` address.     * We cannot reuse create call due to the Organization ownership restrictions. 
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *string* | orgJsonUri | Organization's data pointer |
-| *address* | directory | Segment directory's address |
-
-Outputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* |  | undefined |
-
 ## *function* getCreatedOrganizations
 
 OrganizationFactoryUpgradeabilityTest.getCreatedOrganizations() `view` `270ca0f0`
@@ -87,6 +68,19 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* create
+
+OrganizationFactoryUpgradeabilityTest.create(orgJsonUri, orgJsonHash) `nonpayable` `3dee0c50`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | orgJsonUri | undefined |
+| *bytes32* | orgJsonHash | undefined |
+
 
 ## *function* initialize
 
@@ -129,17 +123,25 @@ Outputs
 |-|-|-|
 | *address* |  | undefined |
 
-## *function* create
+## *function* createAndAddToDirectory
 
-OrganizationFactoryUpgradeabilityTest.create(orgJsonUri) `nonpayable` `b6a46b3b`
+OrganizationFactoryUpgradeabilityTest.createAndAddToDirectory(orgJsonUri, orgJsonHash, directory) `nonpayable` `af276209`
 
+> `createAndAddToDirectory` Creates the organization contract and tries to add it to a SegmentDirectory living on the passed `directory` address.     * We cannot reuse create call due to the Organization ownership restrictions. 
 
 Inputs
 
 | **type** | **name** | **description** |
 |-|-|-|
-| *string* | orgJsonUri | undefined |
+| *string* | orgJsonUri | Organization's data pointer |
+| *bytes32* | orgJsonHash | Organization's data hash |
+| *address* | directory | Segment directory's address |
 
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
 
 ## *function* transferOwnership
 

--- a/docs/OrganizationInterface.md
+++ b/docs/OrganizationInterface.md
@@ -2,6 +2,7 @@
   * [supportsInterface](#function-supportsinterface)
   * [getAssociatedKeys](#function-getassociatedkeys)
   * [getOrgJsonUri](#function-getorgjsonuri)
+  * [getOrgJsonHash](#function-getorgjsonhash)
   * [owner](#function-owner)
   * [hasAssociatedKey](#function-hasassociatedkey)
 
@@ -48,6 +49,20 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *string* |  | undefined |
+
+## *function* getOrgJsonHash
+
+OrganizationInterface.getOrgJsonHash() `view` `72cd7fc9`
+
+> Returns keccak256 hash of raw ORG.JSON contents. This should be used to verify that the contents of ORG.JSON has not been tampered with. It is a responsibility of the Organization owner to keep this hash up to date.
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
 
 ## *function* owner
 

--- a/docs/OrganizationUpgradeabilityTest.md
+++ b/docs/OrganizationUpgradeabilityTest.md
@@ -18,6 +18,7 @@
   * [associatedKeysIndex](#function-associatedkeysindex)
   * [transferOwnership](#function-transferownership)
   * [hasAssociatedKey](#function-hasassociatedkey)
+  * [setInterfaces](#function-setinterfaces)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [OrgJsonUriChanged](#event-orgjsonurichanged)
   * [OrgJsonHashChanged](#event-orgjsonhashchanged)
@@ -263,6 +264,14 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *bool* |  | undefined |
+
+## *function* setInterfaces
+
+OrganizationUpgradeabilityTest.setInterfaces() `nonpayable` `fca85eb3`
+
+
+
+
 ## *event* OwnershipTransferred
 
 OrganizationUpgradeabilityTest.OwnershipTransferred(previousOwner, newOwner) `8be0079c`

--- a/docs/OrganizationUpgradeabilityTest.md
+++ b/docs/OrganizationUpgradeabilityTest.md
@@ -5,17 +5,22 @@
   * [associatedKeys](#function-associatedkeys)
   * [newFunction](#function-newfunction)
   * [getOrgJsonUri](#function-getorgjsonuri)
+  * [orgJsonHash](#function-orgjsonhash)
   * [created](#function-created)
+  * [changeOrgJsonHash](#function-changeorgjsonhash)
   * [orgJsonUri](#function-orgjsonuri)
+  * [getOrgJsonHash](#function-getorgjsonhash)
   * [addAssociatedKey](#function-addassociatedkey)
   * [owner](#function-owner)
+  * [changeOrgJsonUriAndHash](#function-changeorgjsonuriandhash)
   * [changeOrgJsonUri](#function-changeorgjsonuri)
+  * [initialize](#function-initialize)
   * [associatedKeysIndex](#function-associatedkeysindex)
   * [transferOwnership](#function-transferownership)
-  * [initialize](#function-initialize)
   * [hasAssociatedKey](#function-hasassociatedkey)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [OrgJsonUriChanged](#event-orgjsonurichanged)
+  * [OrgJsonHashChanged](#event-orgjsonhashchanged)
   * [AssociatedKeyAdded](#event-associatedkeyadded)
   * [AssociatedKeyRemoved](#event-associatedkeyremoved)
 
@@ -96,12 +101,33 @@ Outputs
 |-|-|-|
 | *string* |  | undefined |
 
+## *function* orgJsonHash
+
+OrganizationUpgradeabilityTest.orgJsonHash() `view` `2095005b`
+
+
+
+
+
 ## *function* created
 
 OrganizationUpgradeabilityTest.created() `view` `325a19f1`
 
 
 
+
+
+## *function* changeOrgJsonHash
+
+OrganizationUpgradeabilityTest.changeOrgJsonHash(_orgJsonHash) `nonpayable` `32fda029`
+
+> `changeOrgJsonHash` Allows owner to change Organization's orgJsonHash.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | _orgJsonHash | keccak256 hash of the new ORG.JSON contents. |
 
 
 ## *function* orgJsonUri
@@ -111,6 +137,20 @@ OrganizationUpgradeabilityTest.orgJsonUri() `view` `3b3ba578`
 
 
 
+
+## *function* getOrgJsonHash
+
+OrganizationUpgradeabilityTest.getOrgJsonHash() `view` `72cd7fc9`
+
+> Returns keccak256 hash of raw ORG.JSON contents. This should be used to verify that the contents of ORG.JSON has not been tampered with. It is a responsibility of the Organization owner to keep this hash up to date.
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* |  | undefined |
 
 ## *function* addAssociatedKey
 
@@ -139,6 +179,20 @@ OrganizationUpgradeabilityTest.owner() `view` `8da5cb5b`
 
 
 
+## *function* changeOrgJsonUriAndHash
+
+OrganizationUpgradeabilityTest.changeOrgJsonUriAndHash(_orgJsonUri, _orgJsonHash) `nonpayable` `a4e99359`
+
+> Shorthand method to change ORG.JSON uri and hash at the same time
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *string* | _orgJsonUri | New orgJsonUri pointer of this Organization |
+| *bytes32* | _orgJsonHash | keccak256 hash of the new ORG.JSON contents. |
+
+
 ## *function* changeOrgJsonUri
 
 OrganizationUpgradeabilityTest.changeOrgJsonUri(_orgJsonUri) `nonpayable` `b454f4ef`
@@ -150,6 +204,21 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *string* | _orgJsonUri | New orgJsonUri pointer of this Organization |
+
+
+## *function* initialize
+
+OrganizationUpgradeabilityTest.initialize(__owner, _orgJsonUri, _orgJsonHash) `nonpayable` `ca303fc7`
+
+> Initializer for upgradeable contracts.
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | __owner | The address of the contract owner |
+| *string* | _orgJsonUri | pointer to Organization data |
+| *bytes32* | _orgJsonHash | keccak256 hash of the new ORG.JSON contents. |
 
 
 ## *function* associatedKeysIndex
@@ -175,20 +244,6 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | newOwner | The address to transfer ownership to. |
-
-
-## *function* initialize
-
-OrganizationUpgradeabilityTest.initialize(__owner, _orgJsonUri) `nonpayable` `f399e22e`
-
-> Initializer for upgradeable contracts.
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __owner | The address of the contract owner |
-| *string* | _orgJsonUri | pointer to Organization data |
 
 
 ## *function* hasAssociatedKey
@@ -227,8 +282,19 @@ Arguments
 
 | **type** | **name** | **description** |
 |-|-|-|
-| *string* | previousOrgJsonUri | indexed |
-| *string* | newOrgJsonUri | indexed |
+| *string* | previousOrgJsonUri | not indexed |
+| *string* | newOrgJsonUri | not indexed |
+
+## *event* OrgJsonHashChanged
+
+OrganizationUpgradeabilityTest.OrgJsonHashChanged(previousOrgJsonHash, newOrgJsonHash) `ccd34c96`
+
+Arguments
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *bytes32* | previousOrgJsonHash | indexed |
+| *bytes32* | newOrgJsonHash | indexed |
 
 ## *event* AssociatedKeyAdded
 

--- a/docs/SegmentDirectory.md
+++ b/docs/SegmentDirectory.md
@@ -2,6 +2,7 @@
   * [add](#function-add)
   * [getSegment](#function-getsegment)
   * [remove](#function-remove)
+  * [resolveLifTokenFromENS](#function-resolveliftokenfromens)
   * [organizationsIndex](#function-organizationsindex)
   * [initialize](#function-initialize)
   * [getLifToken](#function-getliftoken)
@@ -10,7 +11,6 @@
   * [setSegment](#function-setsegment)
   * [getOrganizationsLength](#function-getorganizationslength)
   * [organizations](#function-organizations)
-  * [setLifToken](#function-setliftoken)
   * [transferOwnership](#function-transferownership)
   * [OrganizationAdded](#event-organizationadded)
   * [OrganizationRemoved](#event-organizationremoved)
@@ -62,6 +62,18 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | organization | Organization's address |
+
+
+## *function* resolveLifTokenFromENS
+
+SegmentDirectory.resolveLifTokenFromENS(_ENS) `nonpayable` `423ba56e`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _ENS | undefined |
 
 
 ## *function* organizationsIndex
@@ -178,19 +190,6 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* |  | undefined |
-
-## *function* setLifToken
-
-SegmentDirectory.setLifToken(__lifToken) `nonpayable` `f2f0967b`
-
-> `setLifToken` allows the owner of the contract to change the address of the LifToken contract. Allows to set the address to zero address
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __lifToken | The new contract address |
-
 
 ## *function* transferOwnership
 

--- a/docs/SegmentDirectoryUpgradeabilityTest.md
+++ b/docs/SegmentDirectoryUpgradeabilityTest.md
@@ -3,6 +3,7 @@
   * [newFunction](#function-newfunction)
   * [getSegment](#function-getsegment)
   * [remove](#function-remove)
+  * [resolveLifTokenFromENS](#function-resolveliftokenfromens)
   * [organizationsIndex](#function-organizationsindex)
   * [initialize](#function-initialize)
   * [getLifToken](#function-getliftoken)
@@ -11,7 +12,6 @@
   * [setSegment](#function-setsegment)
   * [getOrganizationsLength](#function-getorganizationslength)
   * [organizations](#function-organizations)
-  * [setLifToken](#function-setliftoken)
   * [transferOwnership](#function-transferownership)
   * [OrganizationAdded](#event-organizationadded)
   * [OrganizationRemoved](#event-organizationremoved)
@@ -71,6 +71,18 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | organization | Organization's address |
+
+
+## *function* resolveLifTokenFromENS
+
+SegmentDirectoryUpgradeabilityTest.resolveLifTokenFromENS(_ENS) `nonpayable` `423ba56e`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _ENS | undefined |
 
 
 ## *function* organizationsIndex
@@ -187,19 +199,6 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* |  | undefined |
-
-## *function* setLifToken
-
-SegmentDirectoryUpgradeabilityTest.setLifToken(__lifToken) `nonpayable` `f2f0967b`
-
-> `setLifToken` allows the owner of the contract to change the address of the LifToken contract. Allows to set the address to zero address
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | __lifToken | The new contract address |
-
 
 ## *function* transferOwnership
 

--- a/docs/WindingTreeEntrypoint.md
+++ b/docs/WindingTreeEntrypoint.md
@@ -5,16 +5,17 @@
   * [setSegment](#function-setsegment)
   * [removeSegment](#function-removesegment)
   * [directories](#function-directories)
+  * [resolveLifTokenFromENS](#function-resolveliftokenfromens)
   * [getSegmentName](#function-getsegmentname)
-  * [LifToken](#function-liftoken)
+  * [_lifToken](#function-_liftoken)
   * [organizationFactory](#function-organizationfactory)
   * [getSegmentsIndex](#function-getsegmentsindex)
+  * [getLifToken](#function-getliftoken)
   * [owner](#function-owner)
   * [segmentsIndex](#function-segmentsindex)
   * [getSegment](#function-getsegment)
   * [setOrganizationFactory](#function-setorganizationfactory)
   * [initialize](#function-initialize)
-  * [setLifToken](#function-setliftoken)
   * [transferOwnership](#function-transferownership)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [SegmentSet](#event-segmentset)
@@ -102,6 +103,18 @@ Inputs
 | *bytes32* |  | undefined |
 
 
+## *function* resolveLifTokenFromENS
+
+WindingTreeEntrypoint.resolveLifTokenFromENS(_ENS) `nonpayable` `423ba56e`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _ENS | undefined |
+
+
 ## *function* getSegmentName
 
 WindingTreeEntrypoint.getSegmentName(index) `view` `45eade19`
@@ -120,9 +133,9 @@ Outputs
 |-|-|-|
 | *string* |  | undefined |
 
-## *function* LifToken
+## *function* _lifToken
 
-WindingTreeEntrypoint.LifToken() `view` `554d8b37`
+WindingTreeEntrypoint._lifToken() `view` `5c8c66ee`
 
 
 
@@ -153,6 +166,20 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* getLifToken
+
+WindingTreeEntrypoint.getLifToken() `view` `8b0728cf`
+
+> `getLifToken` Returns address of set Lif token
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
 
 ## *function* owner
 
@@ -208,7 +235,7 @@ Inputs
 
 ## *function* initialize
 
-WindingTreeEntrypoint.initialize(__owner, _lifToken, _organizationFactory) `nonpayable` `c0c53b8b`
+WindingTreeEntrypoint.initialize(__owner, __lifToken, _organizationFactory) `nonpayable` `c0c53b8b`
 
 > Initializer for upgradeable contracts.
 
@@ -217,21 +244,8 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The LifToken contract address |
+| *address* | __lifToken | The LifToken contract address |
 | *address* | _organizationFactory | The OrganizationFactory contract address |
-
-
-## *function* setLifToken
-
-WindingTreeEntrypoint.setLifToken(_lifToken) `nonpayable` `f2f0967b`
-
-> `setLifToken` allows the owner of the contract to change the address of the LifToken contract. Allows to set the address to zero address
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | _lifToken | The new contract address |
 
 
 ## *function* transferOwnership

--- a/docs/WindingTreeEntrypointUpgradeabilityTest.md
+++ b/docs/WindingTreeEntrypointUpgradeabilityTest.md
@@ -6,16 +6,17 @@
   * [setSegment](#function-setsegment)
   * [removeSegment](#function-removesegment)
   * [directories](#function-directories)
+  * [resolveLifTokenFromENS](#function-resolveliftokenfromens)
   * [getSegmentName](#function-getsegmentname)
-  * [LifToken](#function-liftoken)
+  * [_lifToken](#function-_liftoken)
   * [organizationFactory](#function-organizationfactory)
   * [getSegmentsIndex](#function-getsegmentsindex)
+  * [getLifToken](#function-getliftoken)
   * [owner](#function-owner)
   * [segmentsIndex](#function-segmentsindex)
   * [getSegment](#function-getsegment)
   * [setOrganizationFactory](#function-setorganizationfactory)
   * [initialize](#function-initialize)
-  * [setLifToken](#function-setliftoken)
   * [transferOwnership](#function-transferownership)
   * [OwnershipTransferred](#event-ownershiptransferred)
   * [SegmentSet](#event-segmentset)
@@ -111,6 +112,18 @@ Inputs
 | *bytes32* |  | undefined |
 
 
+## *function* resolveLifTokenFromENS
+
+WindingTreeEntrypointUpgradeabilityTest.resolveLifTokenFromENS(_ENS) `nonpayable` `423ba56e`
+
+
+Inputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* | _ENS | undefined |
+
+
 ## *function* getSegmentName
 
 WindingTreeEntrypointUpgradeabilityTest.getSegmentName(index) `view` `45eade19`
@@ -129,9 +142,9 @@ Outputs
 |-|-|-|
 | *string* |  | undefined |
 
-## *function* LifToken
+## *function* _lifToken
 
-WindingTreeEntrypointUpgradeabilityTest.LifToken() `view` `554d8b37`
+WindingTreeEntrypointUpgradeabilityTest._lifToken() `view` `5c8c66ee`
 
 
 
@@ -162,6 +175,20 @@ Outputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *uint256* |  | undefined |
+
+## *function* getLifToken
+
+WindingTreeEntrypointUpgradeabilityTest.getLifToken() `view` `8b0728cf`
+
+> `getLifToken` Returns address of set Lif token
+
+
+
+Outputs
+
+| **type** | **name** | **description** |
+|-|-|-|
+| *address* |  | undefined |
 
 ## *function* owner
 
@@ -217,7 +244,7 @@ Inputs
 
 ## *function* initialize
 
-WindingTreeEntrypointUpgradeabilityTest.initialize(__owner, _lifToken, _organizationFactory) `nonpayable` `c0c53b8b`
+WindingTreeEntrypointUpgradeabilityTest.initialize(__owner, __lifToken, _organizationFactory) `nonpayable` `c0c53b8b`
 
 > Initializer for upgradeable contracts.
 
@@ -226,21 +253,8 @@ Inputs
 | **type** | **name** | **description** |
 |-|-|-|
 | *address* | __owner | The address of the contract owner |
-| *address* | _lifToken | The LifToken contract address |
+| *address* | __lifToken | The LifToken contract address |
 | *address* | _organizationFactory | The OrganizationFactory contract address |
-
-
-## *function* setLifToken
-
-WindingTreeEntrypointUpgradeabilityTest.setLifToken(_lifToken) `nonpayable` `f2f0967b`
-
-> `setLifToken` allows the owner of the contract to change the address of the LifToken contract. Allows to set the address to zero address
-
-Inputs
-
-| **type** | **name** | **description** |
-|-|-|-|
-| *address* | _lifToken | The new contract address |
 
 
 ## *function* transferOwnership

--- a/management/build-index.js
+++ b/management/build-index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 const fs = require('fs'),
   path = require('path');
 
@@ -9,11 +10,11 @@ const bundle = [
   'OrganizationInterface\.json',
   'SegmentDirectory\.json',
   'Entrypoint\.json',
-]
-const files = fs.readdirSync(CONTRACTS_DIR)
+];
+const files = fs.readdirSync(CONTRACTS_DIR);
 const bundleRegex = new RegExp(bundle.join('|'));
-let importStatements = [];
-let exportStatements = [];
+const importStatements = [];
+const exportStatements = [];
 
 files
   .filter((f) => f.match(bundleRegex))
@@ -29,6 +30,6 @@ ${importStatements.join('\n')}
 module.exports = {
 ${exportStatements.join('\n')}
 };
-`
+`;
 
 console.log(result);

--- a/management/upgrade-organizations.js
+++ b/management/upgrade-organizations.js
@@ -1,0 +1,135 @@
+/**
+ * This cannot be implemented in OrganizationFactory smart contract
+ * due to the fact that proxy admin is the owner account of the OrganizationFactory
+ * and we cannot call BaseAdminUpgradeabilityProxy from OrganizationFactory on behalf
+ * of its owner.
+ */
+const ethjswallet = require('ethereumjs-wallet');
+const HDWalletProvider = require('truffle-hdwallet-provider');
+const TruffleContract = require('truffle-contract');
+const Web3Accounts = require('web3-eth-accounts');
+const Web3Eth = require('web3-eth');
+
+const OrganizationFactoryMetadata = require('../build/contracts/OrganizationFactory.json');
+const BaseAdminUpgradeabilityProxyMetadata = require('zos-lib/build/contracts/BaseAdminUpgradeabilityProxy.json');
+
+function getInfuraNodeAddress (networkName, projectid) {
+  return `https://${networkName}.infura.io/v3/${projectid}`;
+}
+
+function getWeb3Account (provider, keyFile) {
+  const accounts = new Web3Accounts(provider);
+  const hdWalletProvider = new HDWalletProvider(keyFile.mnemonic, provider);
+  const wallet = ethjswallet.fromPrivateKey(hdWalletProvider.wallets[hdWalletProvider.addresses[0]].getPrivateKey());
+  const password = 'temp-password';
+  const keystore = wallet.toV3(password);
+  return accounts.decrypt(keystore, password);
+}
+
+function getContractWithProvider (metadata, provider) {
+  const contract = TruffleContract(metadata);
+  contract.setProvider(provider);
+  return contract;
+};
+
+// we start at 1 because zero index is always zero address
+async function upgradeOrganizations (provider, account, factoryAddress, newImplementationAddress, startIndex = 1, limit = 3) {
+  console.log(`Running under ${account.address} account for factory on ${factoryAddress}. Setting ORG implementation to ${newImplementationAddress}.`);
+  const web3Eth = new Web3Eth(provider);
+  const factory = await (getContractWithProvider(OrganizationFactoryMetadata, provider)).at(factoryAddress);
+  const adminProxy = getContractWithProvider(BaseAdminUpgradeabilityProxyMetadata, provider);
+  const factoryOwner = await factory.owner();
+  const orgLength = await factory.getCreatedOrganizationsLength();
+  // 0. test that the running account is the owner of the organization factory
+  if (factoryOwner !== account.address) {
+    throw new Error(`Cannot work on OrganizationFactory owned by ${factoryOwner}`);
+  }
+  for (let index = startIndex; index < Math.min(startIndex + limit, orgLength); index++) {
+    const orgAddress = await factory.createdOrganizations(index);
+    // 1. filter out zero addresses and addresses the running account is not the owner of
+    if (orgAddress === '0x0000000000000000000000000000000000000000') {
+      console.log(`Cannot change admin of ${orgAddress}: No code`);
+      continue;
+    }
+    const orgProxy = await adminProxy.at(orgAddress);
+    try {
+      const realAdmin = await orgProxy.contract.methods.admin().call({
+        from: factoryOwner,
+      });
+      if (realAdmin !== factoryOwner) {
+        throw new Error(`Cannot work on proxy with owner ${realAdmin}`);
+      }
+    } catch (e) {
+      console.log(`Cannot change admin of ${orgAddress}: ${e.message}`);
+      continue;
+    }
+
+    // 2. call upgrade on all remaining organizations
+    const data = await orgProxy.contract.methods.upgradeTo(newImplementationAddress).encodeABI({
+      from: factoryOwner,
+    });
+    const estimate = await orgProxy.contract.methods.upgradeTo(newImplementationAddress).estimateGas({
+      from: factoryOwner,
+    });
+    const txOpts = {
+      nonce: web3Eth.getTransactionCount(factoryOwner),
+      data: data,
+      from: factoryOwner,
+      to: orgAddress,
+      gas: estimate,
+    };
+    const origImplementation = await orgProxy.contract.methods.implementation().call({
+      from: factoryOwner,
+    });
+    console.log(`Upgrading ${orgAddress} from ${origImplementation} to ${newImplementationAddress}`);
+    if (origImplementation === newImplementationAddress) {
+      console.log(`  ${orgAddress} already upgraded, skipping...`);
+      continue;
+    }
+    const signedTx = await account.signTransaction(txOpts);
+    // we need to wait here to not create nonce gaps
+    await new Promise((resolve, reject) => {
+      return web3Eth.sendSignedTransaction(signedTx.rawTransaction)
+        .on('transactionHash', (hash) => {
+          console.log(`  Upgrading ${orgAddress} in tx ${hash}`);
+        }).on('receipt', (receipt) => {
+          console.log(`  Receipt for ${orgAddress} arrived`);
+          resolve(receipt);
+        }).on('error', (err) => {
+          reject(err);
+        }).catch((err) => {
+          reject(err);
+        });
+    });
+  }
+
+  // 3. report next starting index
+  if (orgLength >= startIndex + limit) {
+    console.log(`Next starting index should be ${startIndex + limit}`);
+  }
+}
+
+module.exports = {
+  upgradeOrganizations,
+};
+
+if (require.main === module) {
+  (async () => {
+    try {
+      const keyFile = require('../keys.json');
+      const provider = getInfuraNodeAddress('ropsten', keyFile.infura_projectid); // 'http://localhost:8545';
+      await upgradeOrganizations(
+        provider, // web3 provider
+        getWeb3Account(provider, keyFile), // web3 account
+        '0x78D1548E03660093B51159De0E615ea8F6B9eaF9', // factory address
+        '0x1AF488913899D05293a678dc84a7096aE4F1b316', // new implementation address
+        1, // starting index in createdOrganizations in factory
+        1 // how many organizations should be upgraded
+      );
+      process.exit(0);
+    } catch (e) {
+      console.log(e);
+      process.exit(1);
+    }
+  })();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8954,14 +8954,14 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.4.0.tgz",
-      "integrity": "sha512-bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "requires": {
         "got": "^9.6.0",
-        "registry-auth-token": "^3.4.0",
+        "registry-auth-token": "^4.0.0",
         "registry-url": "^5.0.0",
-        "semver": "^6.1.1"
+        "semver": "^6.2.0"
       },
       "dependencies": {
         "semver": {
@@ -9597,11 +9597,11 @@
       "dev": true
     },
     "registry-auth-token": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+      "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
       "requires": {
-        "rc": "^1.1.6",
+        "rc": "^1.2.8",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -11944,6 +11944,21 @@
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
           "dev": true
         },
+        "web3": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.0.0-beta.37",
+            "web3-core": "1.0.0-beta.37",
+            "web3-eth": "1.0.0-beta.37",
+            "web3-eth-personal": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-shh": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
         "web3-utils": {
           "version": "1.0.0-beta.37",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
@@ -12025,6 +12040,69 @@
         "websocket": "^1.0.28"
       },
       "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+          "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        },
+        "utf8": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.0.0-beta.37",
+            "web3-core": "1.0.0-beta.37",
+            "web3-eth": "1.0.0-beta.37",
+            "web3-eth-personal": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-shh": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+          "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        },
         "websocket": {
           "version": "1.0.29",
           "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.29.tgz",
@@ -12049,6 +12127,73 @@
         "bn.js": "^4.11.8",
         "ethers": "^4.0.32",
         "web3": "1.0.0-beta.37"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+          "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        },
+        "utf8": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.0.0-beta.37",
+            "web3-core": "1.0.0-beta.37",
+            "web3-eth": "1.0.0-beta.37",
+            "web3-eth-personal": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-shh": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+          "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "truffle-provider": {
@@ -12060,6 +12205,71 @@
         "truffle-error": "^0.0.5",
         "truffle-interface-adapter": "^0.2.0",
         "web3": "1.0.0-beta.37"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+          "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        },
+        "utf8": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.0.0-beta.37",
+            "web3-core": "1.0.0-beta.37",
+            "web3-eth": "1.0.0-beta.37",
+            "web3-eth-personal": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-shh": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+          "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "tslib": {
@@ -12595,28 +12805,41 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
-      "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.0.tgz",
+      "integrity": "sha512-iFrVAexsopX97x0ofBU/7HrCxzovf624qBkjBUeHZDf/G3Sb4tMQtjkCRc5lgVvzureq5SCqDiFDcqnw7eJ0bA==",
+      "dev": true,
       "requires": {
-        "web3-bzz": "1.0.0-beta.37",
-        "web3-core": "1.0.0-beta.37",
-        "web3-eth": "1.0.0-beta.37",
-        "web3-eth-personal": "1.0.0-beta.37",
-        "web3-net": "1.0.0-beta.37",
-        "web3-shh": "1.0.0-beta.37",
-        "web3-utils": "1.0.0-beta.37"
+        "web3-bzz": "1.2.0",
+        "web3-core": "1.2.0",
+        "web3-eth": "1.2.0",
+        "web3-eth-personal": "1.2.0",
+        "web3-net": "1.2.0",
+        "web3-shh": "1.2.0",
+        "web3-utils": "1.2.0"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        "@types/node": {
+          "version": "10.14.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.13.tgz",
+          "integrity": "sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==",
+          "dev": true
+        },
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
         },
         "eth-lib": {
           "version": "0.1.27",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
           "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -12627,28 +12850,439 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        },
-        "utf8": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.37",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
-          "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
+        "ethers": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+          "dev": true,
           "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+              "dev": true
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "oboe": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "dev": true,
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "dev": true
+        },
+        "scrypt.js": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
+          "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
+          "dev": true,
+          "requires": {
+            "scrypt": "^6.0.2",
+            "scryptsy": "^1.2.1"
+          }
+        },
+        "swarm-js": {
+          "version": "0.1.39",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "dev": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.0.tgz",
+          "integrity": "sha512-QEIdvguSEpqBK9b815nzx4yvpfKv/SAvaFeCMjQ0vjIVqFhAwBHDxd+f+X3nWGVRGVeOTP7864tau26CPBtQ8Q==",
+          "dev": true,
+          "requires": {
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.0.tgz",
+          "integrity": "sha512-Vy+fargzx94COdihE79zIM5lb/XAl/LJlgGdmz2a6QhgGZrSL8K6DKKNS+OuORAcLJN2PWNMc4IdfknkOw1PhQ==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-requestmanager": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.0.tgz",
+          "integrity": "sha512-KLCCP2FS1cMz23Y9l3ZaEDzaUky+GpsNavl4Hn1xX8lNaKcfgGEF+DgtAY/TfPQYAxLjLrSbIFUDzo9H/W1WAQ==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.0.tgz",
+          "integrity": "sha512-Iff5rCL+sgHe6zZVZijp818aRixKQf3ZAyQsT6ewER1r9yqXsH89DJtX33Xw8xiaYSwUFcpNs2j+Kluhv/eVAw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.0.tgz",
+          "integrity": "sha512-9THNYsZka91AX4LZGZvka5hio9+QlOY22hNgCiagmCmYytyKk3cXftL6CWefnNF7XgW8sy/ew5lzWLVsQW61Lw==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.0.tgz",
+          "integrity": "sha512-hPe1jyESodXAiE7qJglu7ySo4GINCn5CgG+9G1ATLQbriZsir83QMSeKQekv/hckKFIf4SvZJRPEBhtAle+Dhw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "web3-providers-http": "1.2.0",
+            "web3-providers-ipc": "1.2.0",
+            "web3-providers-ws": "1.2.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.0.tgz",
+          "integrity": "sha512-DHipGH8It5E4HxxvymhkudcYhBVgGx6MwGWobIVKFgp6JRxtuvAbqwrMbuD/+78J6yXOa4y9zVXBk12dm2NXGg==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.0.tgz",
+          "integrity": "sha512-GP1+hHS/IVW1tAOIDS44PxCpvSl9PBU/KAB40WgP27UMvSy43LjHxGlP6hQQOdIfmBLBTvGvn2n+Z5kW2gzAzg==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-eth-accounts": "1.2.0",
+            "web3-eth-contract": "1.2.0",
+            "web3-eth-ens": "1.2.0",
+            "web3-eth-iban": "1.2.0",
+            "web3-eth-personal": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.0.tgz",
+          "integrity": "sha512-FDuPq/tFeMg/D/f7cNSmvVYkMYb1z379gUUzSL8ZFtZrdHPkezq+lq/TmWmbCOMLYNXlhGJBzjGdLXRS4Upprg==",
+          "dev": true,
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.0.tgz",
+          "integrity": "sha512-d/fUAL3F6HqstvEiBnZ1RwZ77/DytgF9d6A3mWVvPOUk2Pqi77PM0adRvsKvIWUaQ/k6OoCk/oXtbzaO7CyGpg==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "^0.3.0",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-utils": "1.2.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.0.tgz",
+          "integrity": "sha512-hfjozNbfsoMeR3QklfkwU0Mqcw6YRD4y1Cb1ghGWNhFy2+/sbvKcQNPPJDKFTde22PRzGQBWyh/nb422Sux4bQ==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.0.tgz",
+          "integrity": "sha512-kE6uHMLwH9dv+MZSKT7BcKXcQ6CcLP5m5mM44s2zg2e9Rl20F3J6R3Ik6sLc/w2ywdCwTe/Z22yEstHXQwu5ig==",
+          "dev": true,
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-eth-contract": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.0.tgz",
+          "integrity": "sha512-6DzTx/cvIgEvxadhJjLGpsuDUARA4RKskNOuwWYUsUODcPb50rsfMmRkHhGtLss/sNXVE5gNjbT9rX3TDqy2tg==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.0.tgz",
+          "integrity": "sha512-8QdcaT6dbdiMC8zEqvDuij8XeI34r2GGdQYGvYBP2UgCm15EZBHgewxO30A+O+j2oIW1/Hu60zP5upnhCuA1Dw==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.0.tgz",
+          "integrity": "sha512-7iD8C6vvx8APXPMmlpPLGWjn4bsXHzd3BTdFzKjkoYjiiVFJdVAbY3j1BwN/6tVQu8Ay7sDpV2EdTNub7GKbyw==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.0.tgz",
+          "integrity": "sha512-UrUn6JSz7NVCZ+0nZZtC4cmbl5JIi57w1flL1jN8jgkfdWDdErNvTkSwCt/QYdTQscMaUtWXDDOSAsVO6YC64g==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.0",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.0.tgz",
+          "integrity": "sha512-T2OSbiqu7+dahbGG5YFEQM5+FXdLVvaTCKmHXaQpw8IuL5hw7HELtyFOtHVudgDRyw0tJKxIfAiX/v2F1IL1fQ==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.0.tgz",
+          "integrity": "sha512-rnwGcCe6cev5A6eG5UBCQqPmkJVZMCrK+HN1AvUCco0OHD/0asGc9LuLbtkQIyznA6Lzetq/OOcaTOM4KeT11g==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "websocket": "github:frozeman/WebSocket-Node#browserifyCompatible"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.0.tgz",
+          "integrity": "sha512-VFjS8kvsQBodudFmIoVJWvDNZosONJZZnhvktngD3POu5dwbJmSCl6lzbLJ2C5XjR15dF+JvSstAkWbM+2sdPg==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-net": "1.2.0"
+          }
+        },
+        "websocket": {
+          "version": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "github:frozeman/WebSocket-Node#browserifyCompatible",
+          "dev": true,
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
           }
         }
       }
@@ -13775,9 +14409,9 @@
       }
     },
     "web3-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0.tgz",
-      "integrity": "sha512-zm0gdLXLk54ldwxxBMNPS62EuqHI2PaJohEGijTowacNS0BS2vEXdriNA8gp1+EplP2WgoHE0uRVmQIfpAyV+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.0.tgz",
+      "integrity": "sha512-tI1low8ICoaWU2c53cikH0rsksKuIskI2nycH5E5sEXxxl9/BOD3CeDDBFbxgNPQ+bpDevbR7gXNEDB7Ud4G9g==",
       "requires": {
         "bn.js": "4.11.8",
         "eth-lib": "0.2.7",
@@ -14170,6 +14804,27 @@
           "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
           "dev": true
         },
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+          "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -14241,6 +14896,48 @@
           "requires": {
             "chalk": "^2.4.2",
             "cli-cursor": "^3.0.0"
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        },
+        "utf8": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.0.0-beta.37",
+            "web3-core": "1.0.0-beta.37",
+            "web3-eth": "1.0.0-beta.37",
+            "web3-eth-personal": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-shh": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+          "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
           }
         }
       }
@@ -14315,6 +15012,20 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
+        },
+        "web3": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
+          "requires": {
+            "web3-bzz": "1.0.0-beta.37",
+            "web3-core": "1.0.0-beta.37",
+            "web3-eth": "1.0.0-beta.37",
+            "web3-eth-personal": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-shh": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
         },
         "web3-utils": {
           "version": "1.0.0-beta.37",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "truffle-contract": "^4.0.24",
     "truffle-flattener": "^1.4.0",
     "truffle-hdwallet-provider": "^1.0.14",
-    "web3": "1.0.0-beta.37",
-    "web3-utils": "1.0.0",
+    "web3": "^1.2.0",
+    "web3-utils": "^1.2.0",
     "zos": "^2.4.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "solmd": "^0.4.0",
     "truffle": "^5.0.27",
     "truffle-contract": "^4.0.24",
-    "truffle-flattener": "^1.3.0",
+    "truffle-flattener": "^1.4.0",
     "truffle-hdwallet-provider": "^1.0.14",
     "web3": "1.0.0-beta.37",
     "web3-utils": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "test": "management/test.sh",
-    "lint": "eslint test && solhint 'contracts/**/*.sol'",
-    "lint:fix": "eslint test --fix && solhint 'contracts/**/*.sol'",
+    "lint": "eslint test management && solhint 'contracts/**/*.sol'",
+    "lint:fix": "eslint test management --fix && solhint 'contracts/**/*.sol'",
     "dev-net": "./node_modules/.bin/ganache-cli --gasLimit 0xfffffffffff --deterministic --port 8545 --account=\"0xe8280389ca1303a2712a874707fdd5d8ae0437fab9918f845d26fd9919af5a92,10000000000000000000000000000000000000000000000000000000000000000000000000000000\" --account=\"0xa4605db83bb3e663f33fb92542ca38344bd8d1bf2d07cc6cc908fec87b7674d5,10000000000000000000000000000000000000000000000000000000000000000000000000000000\"",
     "coverage": "SOLIDITY_COVERAGE=true npm run test",
     "soldoc": "management/soldoc.sh",
@@ -55,6 +55,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "eth-ens-namehash": "^2.0.8",
     "ethereumjs-util": "^6.1.0",
+    "ethereumjs-wallet": "^0.6.3",
     "ganache-cli": "^6.4.5",
     "lodash": "^4.17.14",
     "rimraf": "^2.6.3",

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -64,10 +64,11 @@ async function deployLifToken () {
 async function getOrganizationInfo (wtOrganization) {
   // Airline Info
   const orgJsonUri = await wtOrganization.methods.getOrgJsonUri().call();
+  const orgJsonHash = await wtOrganization.methods.getOrgJsonHash().call();
   const owner = await wtOrganization.methods.owner().call();
-
   return {
     orgJsonUri: misc.isZeroString(orgJsonUri) ? null : orgJsonUri,
+    orgJsonHash: misc.isZeroBytes(orgJsonHash) ? null : orgJsonHash,
     owner: misc.isZeroAddress(owner) ? null : owner,
   };
 }

--- a/test/helpers/misc.js
+++ b/test/helpers/misc.js
@@ -19,6 +19,10 @@ module.exports = {
     return parseInt(val) === 0;
   },
 
+  isZeroBytes: function (val) {
+    return parseInt(val) === 0;
+  },
+
   isInvalidOpcodeEx: function (e) {
     if (
       e.message.search('invalid opcode') >= 0 || // ethereumjs-testrpc at least <= 4

--- a/test/organization-factory.js
+++ b/test/organization-factory.js
@@ -284,6 +284,8 @@ contract('OrganizationFactory', (accounts) => {
         const orgProxy = await AdminUpgradeabilityProxy.at(organization);
         if (organization !== nonOwnedOrganization) {
           assert.equal(await orgProxy.methods.implementation().call({ from: organizationFactoryOwner }), newImplementation);
+          const org = await OrganizationInterface.at(organization);
+          assert.equal(await org.methods.supportsInterface('0x1b28d63e').call({ from: tokenAddress }), true);
         } else {
           assert.equal(await orgProxy.methods.implementation().call({ from: nonOwnerAccount }), origImplementation);
         }

--- a/test/organization.js
+++ b/test/organization.js
@@ -10,6 +10,7 @@ Contracts.setArtifactsDefaults({
 });
 
 const Organization = Contracts.getFromLocal('Organization');
+const OrganizationInterface = Contracts.getFromLocal('OrganizationInterface');
 const OrganizationUpgradeabilityTest = Contracts.getFromLocal('OrganizationUpgradeabilityTest');
 
 contract('Organization', (accounts) => {
@@ -82,6 +83,28 @@ contract('Organization', (accounts) => {
       } catch (e) {
         assert(help.isInvalidOpcodeEx(e));
       }
+    });
+  });
+
+  describe('interoperability', () => {
+    it('should support IERC165 interface', async () => {
+      const orgIface = await OrganizationInterface.at(organization.address);
+      assert.equal(await orgIface.methods.supportsInterface('0x01ffc9a7').call(), true);
+    });
+
+    it('should support ORG.JSON related interface', async () => {
+      const orgIface = await OrganizationInterface.at(organization.address);
+      assert.equal(await orgIface.methods.supportsInterface('0x6f4826be').call(), true);
+    });
+
+    it('should support associated keys related interface', async () => {
+      const orgIface = await OrganizationInterface.at(organization.address);
+      assert.equal(await orgIface.methods.supportsInterface('0xfed71811').call(), true);
+    });
+
+    it('should support latest interface', async () => {
+      const orgIface = await OrganizationInterface.at(organization.address);
+      assert.equal(await orgIface.methods.supportsInterface('0x1c3af5f4').call(), true);
     });
   });
 

--- a/test/organization.js
+++ b/test/organization.js
@@ -107,6 +107,51 @@ contract('Organization', (accounts) => {
     });
   });
 
+  describe('changeOrgJsonHash', () => {
+    const newOrgJsonHash = '0xd1e15bcea4bbf5fa55e36bb5aa9ad5183a4acdc1b06a0f21f3dba8868dee2c99';
+    it('should not set empty orgJsonHash', async () => {
+      try {
+        await organization.methods.changeOrgJsonHash('0x0').send({ from: organizationOwner });
+        assert(false);
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+
+    it('should set orgJsonHash', async () => {
+      const receipt = await organization.methods.changeOrgJsonHash(newOrgJsonHash).send({ from: organizationOwner });
+      const info = await help.getOrganizationInfo(organization);
+      assert.equal(info.orgJsonHash, newOrgJsonHash);
+      assert.isDefined(receipt.events.OrgJsonHashChanged);
+      assert.equal(receipt.events.OrgJsonHashChanged.returnValues.newOrgJsonHash, newOrgJsonHash);
+    });
+
+    it('should throw if not executed by organization owner', async () => {
+      try {
+        await organization.methods.changeOrgJsonHash(newOrgJsonHash).send({ from: nonOwnerAccount });
+        assert(false);
+      } catch (e) {
+        assert(help.isInvalidOpcodeEx(e));
+      }
+    });
+  });
+
+  describe('changeOrgJsonUriAndHash', () => {
+    const newOrgJsonUri = 'goo.gl/12345';
+    const newOrgJsonHash = '0xd1e15bcea4bbf5fa55e36bb5aa9ad5183a4acdc1b06a0f21f3dba8868dee2c99';
+
+    it('should set orgJsonUri and orgJsonHash', async () => {
+      const receipt = await organization.methods.changeOrgJsonUriAndHash(newOrgJsonUri, newOrgJsonHash).send({ from: organizationOwner });
+      const info = await help.getOrganizationInfo(organization);
+      assert.equal(info.orgJsonUri, newOrgJsonUri);
+      assert.equal(info.orgJsonHash, newOrgJsonHash);
+      assert.isDefined(receipt.events.OrgJsonHashChanged);
+      assert.isDefined(receipt.events.OrgJsonUriChanged);
+      assert.equal(receipt.events.OrgJsonHashChanged.returnValues.newOrgJsonHash, newOrgJsonHash);
+      assert.equal(receipt.events.OrgJsonUriChanged.returnValues.newOrgJsonUri, newOrgJsonUri);
+    });
+  });
+
   describe('transferOwnership', () => {
     it('should transfer contract and emit OwnershipTransferred', async () => {
       const receipt = await organization.methods.transferOwnership(nonOwnerAccount).send({ from: organizationOwner });


### PR DESCRIPTION
Improves security by storing and requiring a hash of the entire linked ORG.JSON file.

TODO

- [x] script for migrating all organizations from an organization factory to the new implementation
- [x] example in README
- [x] The upgrade script does not update the `supportedInterfaces` array of the Organization. Since https://github.com/windingtree/trust-clue-lif-deposit/pull/14 started to use it, we should make sure that the interface IDs are consistent after upgrade. We should then figure out a safer way of extending the OrganizationInterface in the future ~in a separate issue~ (I did it here, we need it for https://github.com/windingtree/trust-clue-lif-deposit/pull/14).
- [x] Documented in https://github.com/windingtree/developers/pull/69