### PR TITLE
0.8.2v mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,9 @@ to play with this locally. You can get the ZOS_APP_ADDRESS from the zos dev file
     These commands will return a network address where you can actually interact with the contracts.
     For a quick test, you can use the openzeppelin sdk, you can get all addresses from the zos file that was created.
     ```bash
-    > ./node_modules/.bin/openzeppelin send-tx --network development --to WINDINGTREEENTRYPOINT_PROXY_ADDRESS --method setSegment --args 'hotels',SEGMENTHOTEL_PROXY_ADDRESS --from 0xeb3d7449df1453ac074492a9fc73f6aebdfe9b2f
-    > ./node_modules/.bin/openzeppelin send-tx --network development --to ORGFACTORY_PROXY_ADDRESS --method create --args 'https://windingtree.com','0xd1e15bcea4bbf5fa55e36bb5aa9ad5183a4acdc1b06a0f21f3dba8868dee2c99' --from 0x14f016e73a18c5a68c475d2dff17af38f85db6b7
+    > ./node_modules/.bin/openzeppelin send-tx --network development --to WINDINGTREEENTRYPOINT_PROXY_ADDRESS --method setOrganizationFactory --args ORG_FACTORY_PROXY_ADDRESS --from WT_OWNER
+    > ./node_modules/.bin/openzeppelin send-tx --network development --to WINDINGTREEENTRYPOINT_PROXY_ADDRESS --method setSegment --args 'hotels',SEGMENTHOTEL_PROXY_ADDRESS --from 0xeb3d7449df1453ac074492a9fc73f6aebdfe9b2f --from WT_OWNER
+    > ./node_modules/.bin/openzeppelin send-tx --network development --to ORGFACTORY_PROXY_ADDRESS --method createAndAddToDirectory --args 'https://windingtree.com','0xd1e15bcea4bbf5fa55e36bb5aa9ad5183a4acdc1b06a0f21f3dba8868dee2c99',SEGMENTHOTEL_PROXY_ADDRESS --from 0x14f016e73a18c5a68c475d2dff17af38f85db6b7
     > ./node_modules/.bin/openzeppelin call --network development --to SEGMENTHOTEL_PROXY_ADDRESS --method getOrganizations
     > ./node_modules/.bin/openzeppelin call --network development --to ORGANIZATION_ADDRESS --method getOrgJsonUri
     > ./node_modules/.bin/openzeppelin call --network development --to ORGANIZATION_ADDRESS --method getOrgJsonUri

--- a/zos.mainnet.json
+++ b/zos.mainnet.json
@@ -1,11 +1,11 @@
 {
   "contracts": {
     "WindingTreeEntrypoint": {
-      "address": "0x4e98d051820bA15c0fdE68cD312b95Ee86225e56",
-      "constructorCode": "608060405234801561001057600080fd5b50610f19806100206000396000f3fe",
-      "bodyBytecodeHash": "cbf401acad2088d07c0ac40d9156806d8cd6df941dfaaa66c70b2b604bd2f549",
-      "localBytecodeHash": "13ec41d878ca531a8a4969768b4a84937de840c0ae76bdca35a6fa3883fd6823",
-      "deployedBytecodeHash": "13ec41d878ca531a8a4969768b4a84937de840c0ae76bdca35a6fa3883fd6823",
+      "address": "0xB5c9Dd467f57937c2b9B8B075757f7D53809B8aE",
+      "constructorCode": "608060405234801561001057600080fd5b5061134f806100206000396000f3fe",
+      "bodyBytecodeHash": "2adf3d1fea44c1a6f4e7a34e025053f921878d5155607eee957e19de8dda8bf2",
+      "localBytecodeHash": "bc507cc165fb9ef8fee4d43985a20c49c2fa25f0ab3906e53e2e23cb4b773bb8",
+      "deployedBytecodeHash": "bc507cc165fb9ef8fee4d43985a20c49c2fa25f0ab3906e53e2e23cb4b773bb8",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -57,75 +57,75 @@
       "storage": [
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initialized",
-          "astId": 1924,
+          "astId": 2376,
           "type": "t_bool",
-          "src": "757:24:15"
+          "src": "757:24:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initializing",
-          "astId": 1926,
+          "astId": 2378,
           "type": "t_bool",
-          "src": "876:25:15"
+          "src": "876:25:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 1982,
+          "astId": 2434,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:15"
+          "src": "1951:29:14"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "_owner",
-          "astId": 1164,
+          "astId": 1387,
           "type": "t_address",
-          "src": "400:14:6"
+          "src": "513:14:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
-          "label": "LifToken",
-          "astId": 1166,
+          "label": "_lifToken",
+          "astId": 1389,
           "type": "t_address",
-          "src": "513:23:6"
+          "src": "626:24:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "directories",
-          "astId": 1170,
+          "astId": 1393,
           "type": "t_mapping<t_address>",
-          "src": "601:46:6"
+          "src": "715:46:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "segmentsIndex",
-          "astId": 1174,
+          "astId": 1397,
           "type": "t_mapping<t_uint256>",
-          "src": "718:45:6"
+          "src": "832:45:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "segments",
-          "astId": 1177,
+          "astId": 1400,
           "type": "t_array:dyn<t_string>",
-          "src": "805:24:6"
+          "src": "919:24:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "organizationFactory",
-          "astId": 1179,
+          "astId": 1402,
           "type": "t_address",
-          "src": "875:34:6"
+          "src": "989:34:6"
         }
       ],
       "warnings": {
@@ -133,17 +133,15 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [],
-        "storageDiff": []
+        "uninitializedBaseContracts": []
       }
     },
     "PlaygroundEntrypoint": {
-      "address": "0x8D253a9da687fD39B18E9f3e6f369C9b68Fc24b5",
-      "constructorCode": "608060405234801561001057600080fd5b50610f19806100206000396000f3fe",
-      "bodyBytecodeHash": "cbf401acad2088d07c0ac40d9156806d8cd6df941dfaaa66c70b2b604bd2f549",
-      "localBytecodeHash": "13ec41d878ca531a8a4969768b4a84937de840c0ae76bdca35a6fa3883fd6823",
-      "deployedBytecodeHash": "13ec41d878ca531a8a4969768b4a84937de840c0ae76bdca35a6fa3883fd6823",
+      "address": "0x49D248D38AB4572D14E35296664e0345aA66B7f9",
+      "constructorCode": "608060405234801561001057600080fd5b5061134f806100206000396000f3fe",
+      "bodyBytecodeHash": "2adf3d1fea44c1a6f4e7a34e025053f921878d5155607eee957e19de8dda8bf2",
+      "localBytecodeHash": "bc507cc165fb9ef8fee4d43985a20c49c2fa25f0ab3906e53e2e23cb4b773bb8",
+      "deployedBytecodeHash": "bc507cc165fb9ef8fee4d43985a20c49c2fa25f0ab3906e53e2e23cb4b773bb8",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -195,75 +193,75 @@
       "storage": [
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initialized",
-          "astId": 1924,
+          "astId": 2376,
           "type": "t_bool",
-          "src": "757:24:15"
+          "src": "757:24:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initializing",
-          "astId": 1926,
+          "astId": 2378,
           "type": "t_bool",
-          "src": "876:25:15"
+          "src": "876:25:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 1982,
+          "astId": 2434,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:15"
+          "src": "1951:29:14"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "_owner",
-          "astId": 1164,
+          "astId": 1387,
           "type": "t_address",
-          "src": "400:14:6"
+          "src": "513:14:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
-          "label": "LifToken",
-          "astId": 1166,
+          "label": "_lifToken",
+          "astId": 1389,
           "type": "t_address",
-          "src": "513:23:6"
+          "src": "626:24:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "directories",
-          "astId": 1170,
+          "astId": 1393,
           "type": "t_mapping<t_address>",
-          "src": "601:46:6"
+          "src": "715:46:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "segmentsIndex",
-          "astId": 1174,
+          "astId": 1397,
           "type": "t_mapping<t_uint256>",
-          "src": "718:45:6"
+          "src": "832:45:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "segments",
-          "astId": 1177,
+          "astId": 1400,
           "type": "t_array:dyn<t_string>",
-          "src": "805:24:6"
+          "src": "919:24:6"
         },
         {
           "contract": "WindingTreeEntrypoint",
           "path": "contracts/WindingTreeEntrypoint.sol",
           "label": "organizationFactory",
-          "astId": 1179,
+          "astId": 1402,
           "type": "t_address",
-          "src": "875:34:6"
+          "src": "989:34:6"
         }
       ],
       "warnings": {
@@ -271,17 +269,15 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [],
-        "storageDiff": []
+        "uninitializedBaseContracts": []
       }
     },
     "PlaygroundHotelDirectory": {
-      "address": "0x7e2C420E83395d6f11fE8Aae829297c587175059",
-      "constructorCode": "608060405234801561001057600080fd5b50610f39806100206000396000f3fe",
-      "bodyBytecodeHash": "59cebe23c84ac10314ed713b6977671aecb38548055b94a676f70fc55606b447",
-      "localBytecodeHash": "354d6eaecced205238e77f0a291defb7ada8d0678909e78dc388496cb1aa0a69",
-      "deployedBytecodeHash": "354d6eaecced205238e77f0a291defb7ada8d0678909e78dc388496cb1aa0a69",
+      "address": "0x9B0fD1380D847bc71efCe7652F53fA730b07443D",
+      "constructorCode": "608060405234801561001057600080fd5b5061136d806100206000396000f3fe",
+      "bodyBytecodeHash": "0dbcf1bd632b41c9326ab7117400ae431c36bf42b94603d6c4ed1a997794715f",
+      "localBytecodeHash": "8af6b4041cc786152cf36650d9288f68df4181a980f221f66d5e0fa575c21b7e",
+      "deployedBytecodeHash": "8af6b4041cc786152cf36650d9288f68df4181a980f221f66d5e0fa575c21b7e",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -327,67 +323,67 @@
       "storage": [
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initialized",
-          "astId": 1924,
+          "astId": 2376,
           "type": "t_bool",
-          "src": "757:24:15"
+          "src": "757:24:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initializing",
-          "astId": 1926,
+          "astId": 2378,
           "type": "t_bool",
-          "src": "876:25:15"
+          "src": "876:25:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 1982,
+          "astId": 2434,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:15"
+          "src": "1951:29:14"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_owner",
-          "astId": 800,
+          "astId": 971,
           "type": "t_address",
-          "src": "495:14:5"
+          "src": "608:14:5"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_segment",
-          "astId": 802,
+          "astId": 973,
           "type": "t_string",
-          "src": "558:15:5"
+          "src": "671:15:5"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_organizations",
-          "astId": 805,
+          "astId": 976,
           "type": "t_array:dyn<t_address>",
-          "src": "634:24:5"
+          "src": "747:24:5"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_organizationsIndex",
-          "astId": 809,
+          "astId": 980,
           "type": "t_mapping<t_uint256>",
-          "src": "740:44:5"
+          "src": "853:44:5"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_lifToken",
-          "astId": 811,
+          "astId": 982,
           "type": "t_address",
-          "src": "831:17:5"
+          "src": "944:17:5"
         }
       ],
       "warnings": {
@@ -395,265 +391,15 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [],
-        "storageDiff": []
-      }
-    },
-    "PlaygroundAirlineDirectory": {
-      "address": "0xd43Ec78f36F58A21228a1Be0C33D1e48baA3D1b7",
-      "constructorCode": "608060405234801561001057600080fd5b50610f39806100206000396000f3fe",
-      "bodyBytecodeHash": "59cebe23c84ac10314ed713b6977671aecb38548055b94a676f70fc55606b447",
-      "localBytecodeHash": "354d6eaecced205238e77f0a291defb7ada8d0678909e78dc388496cb1aa0a69",
-      "deployedBytecodeHash": "354d6eaecced205238e77f0a291defb7ada8d0678909e78dc388496cb1aa0a69",
-      "types": {
-        "t_bool": {
-          "id": "t_bool",
-          "kind": "elementary",
-          "label": "bool"
-        },
-        "t_uint256": {
-          "id": "t_uint256",
-          "kind": "elementary",
-          "label": "uint256"
-        },
-        "t_array:50<t_uint256>": {
-          "id": "t_array:50<t_uint256>",
-          "valueType": "t_uint256",
-          "length": "50",
-          "kind": "array",
-          "label": "uint256[50]"
-        },
-        "t_address": {
-          "id": "t_address",
-          "kind": "elementary",
-          "label": "address"
-        },
-        "t_string": {
-          "id": "t_string",
-          "kind": "elementary",
-          "label": "string"
-        },
-        "t_array:dyn<t_address>": {
-          "id": "t_array:dyn<t_address>",
-          "valueType": "t_address",
-          "length": "dyn",
-          "kind": "array",
-          "label": "address[]"
-        },
-        "t_mapping<t_uint256>": {
-          "id": "t_mapping<t_uint256>",
-          "valueType": "t_uint256",
-          "label": "mapping(key => uint256)",
-          "kind": "mapping"
-        }
-      },
-      "storage": [
-        {
-          "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
-          "label": "initialized",
-          "astId": 1924,
-          "type": "t_bool",
-          "src": "757:24:15"
-        },
-        {
-          "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
-          "label": "initializing",
-          "astId": 1926,
-          "type": "t_bool",
-          "src": "876:25:15"
-        },
-        {
-          "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
-          "label": "______gap",
-          "astId": 1982,
-          "type": "t_array:50<t_uint256>",
-          "src": "1951:29:15"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_owner",
-          "astId": 800,
-          "type": "t_address",
-          "src": "495:14:5"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_segment",
-          "astId": 802,
-          "type": "t_string",
-          "src": "558:15:5"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_organizations",
-          "astId": 805,
-          "type": "t_array:dyn<t_address>",
-          "src": "634:24:5"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_organizationsIndex",
-          "astId": 809,
-          "type": "t_mapping<t_uint256>",
-          "src": "740:44:5"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_lifToken",
-          "astId": 811,
-          "type": "t_address",
-          "src": "831:17:5"
-        }
-      ],
-      "warnings": {
-        "hasConstructor": false,
-        "hasSelfDestruct": false,
-        "hasDelegateCall": false,
-        "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [],
-        "storageDiff": []
-      }
-    },
-    "PlaygroundOtaDirectory": {
-      "address": "0x7e7F40b5A8300cd984848e08708Ab8E52d60F8d7",
-      "constructorCode": "608060405234801561001057600080fd5b50610f39806100206000396000f3fe",
-      "bodyBytecodeHash": "59cebe23c84ac10314ed713b6977671aecb38548055b94a676f70fc55606b447",
-      "localBytecodeHash": "354d6eaecced205238e77f0a291defb7ada8d0678909e78dc388496cb1aa0a69",
-      "deployedBytecodeHash": "354d6eaecced205238e77f0a291defb7ada8d0678909e78dc388496cb1aa0a69",
-      "types": {
-        "t_bool": {
-          "id": "t_bool",
-          "kind": "elementary",
-          "label": "bool"
-        },
-        "t_uint256": {
-          "id": "t_uint256",
-          "kind": "elementary",
-          "label": "uint256"
-        },
-        "t_array:50<t_uint256>": {
-          "id": "t_array:50<t_uint256>",
-          "valueType": "t_uint256",
-          "length": "50",
-          "kind": "array",
-          "label": "uint256[50]"
-        },
-        "t_address": {
-          "id": "t_address",
-          "kind": "elementary",
-          "label": "address"
-        },
-        "t_string": {
-          "id": "t_string",
-          "kind": "elementary",
-          "label": "string"
-        },
-        "t_array:dyn<t_address>": {
-          "id": "t_array:dyn<t_address>",
-          "valueType": "t_address",
-          "length": "dyn",
-          "kind": "array",
-          "label": "address[]"
-        },
-        "t_mapping<t_uint256>": {
-          "id": "t_mapping<t_uint256>",
-          "valueType": "t_uint256",
-          "label": "mapping(key => uint256)",
-          "kind": "mapping"
-        }
-      },
-      "storage": [
-        {
-          "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
-          "label": "initialized",
-          "astId": 1924,
-          "type": "t_bool",
-          "src": "757:24:15"
-        },
-        {
-          "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
-          "label": "initializing",
-          "astId": 1926,
-          "type": "t_bool",
-          "src": "876:25:15"
-        },
-        {
-          "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
-          "label": "______gap",
-          "astId": 1982,
-          "type": "t_array:50<t_uint256>",
-          "src": "1951:29:15"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_owner",
-          "astId": 800,
-          "type": "t_address",
-          "src": "495:14:5"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_segment",
-          "astId": 802,
-          "type": "t_string",
-          "src": "558:15:5"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_organizations",
-          "astId": 805,
-          "type": "t_array:dyn<t_address>",
-          "src": "634:24:5"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_organizationsIndex",
-          "astId": 809,
-          "type": "t_mapping<t_uint256>",
-          "src": "740:44:5"
-        },
-        {
-          "contract": "SegmentDirectory",
-          "path": "contracts/SegmentDirectory.sol",
-          "label": "_lifToken",
-          "astId": 811,
-          "type": "t_address",
-          "src": "831:17:5"
-        }
-      ],
-      "warnings": {
-        "hasConstructor": false,
-        "hasSelfDestruct": false,
-        "hasDelegateCall": false,
-        "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [],
-        "storageDiff": []
+        "uninitializedBaseContracts": []
       }
     },
     "SegmentDirectory": {
-      "address": "0xB1A1f9Ca5198d60fd8a37C065568984e40250Fad",
-      "constructorCode": "608060405234801561001057600080fd5b50610f39806100206000396000f3fe",
-      "bodyBytecodeHash": "59cebe23c84ac10314ed713b6977671aecb38548055b94a676f70fc55606b447",
-      "localBytecodeHash": "354d6eaecced205238e77f0a291defb7ada8d0678909e78dc388496cb1aa0a69",
-      "deployedBytecodeHash": "354d6eaecced205238e77f0a291defb7ada8d0678909e78dc388496cb1aa0a69",
+      "address": "0x233d1be9C8812F6D1cBE2dc966Ba444f63354E86",
+      "constructorCode": "608060405234801561001057600080fd5b5061136d806100206000396000f3fe",
+      "bodyBytecodeHash": "0dbcf1bd632b41c9326ab7117400ae431c36bf42b94603d6c4ed1a997794715f",
+      "localBytecodeHash": "8af6b4041cc786152cf36650d9288f68df4181a980f221f66d5e0fa575c21b7e",
+      "deployedBytecodeHash": "8af6b4041cc786152cf36650d9288f68df4181a980f221f66d5e0fa575c21b7e",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -699,67 +445,67 @@
       "storage": [
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initialized",
-          "astId": 1924,
+          "astId": 2376,
           "type": "t_bool",
-          "src": "757:24:15"
+          "src": "757:24:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initializing",
-          "astId": 1926,
+          "astId": 2378,
           "type": "t_bool",
-          "src": "876:25:15"
+          "src": "876:25:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 1982,
+          "astId": 2434,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:15"
+          "src": "1951:29:14"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_owner",
-          "astId": 800,
+          "astId": 971,
           "type": "t_address",
-          "src": "495:14:5"
+          "src": "608:14:5"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_segment",
-          "astId": 802,
+          "astId": 973,
           "type": "t_string",
-          "src": "558:15:5"
+          "src": "671:15:5"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_organizations",
-          "astId": 805,
+          "astId": 976,
           "type": "t_array:dyn<t_address>",
-          "src": "634:24:5"
+          "src": "747:24:5"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_organizationsIndex",
-          "astId": 809,
+          "astId": 980,
           "type": "t_mapping<t_uint256>",
-          "src": "740:44:5"
+          "src": "853:44:5"
         },
         {
           "contract": "SegmentDirectory",
           "path": "contracts/SegmentDirectory.sol",
           "label": "_lifToken",
-          "astId": 811,
+          "astId": 982,
           "type": "t_address",
-          "src": "831:17:5"
+          "src": "944:17:5"
         }
       ],
       "warnings": {
@@ -767,17 +513,259 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [],
-        "storageDiff": []
+        "uninitializedBaseContracts": []
+      }
+    },
+    "PlaygroundAirlineDirectory": {
+      "address": "0x43D5DCd3E3F6D80FfA723eed64b0BEB22f6B0Fc9",
+      "constructorCode": "608060405234801561001057600080fd5b5061136d806100206000396000f3fe",
+      "bodyBytecodeHash": "0dbcf1bd632b41c9326ab7117400ae431c36bf42b94603d6c4ed1a997794715f",
+      "localBytecodeHash": "8af6b4041cc786152cf36650d9288f68df4181a980f221f66d5e0fa575c21b7e",
+      "deployedBytecodeHash": "8af6b4041cc786152cf36650d9288f68df4181a980f221f66d5e0fa575c21b7e",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_address": {
+          "id": "t_address",
+          "kind": "elementary",
+          "label": "address"
+        },
+        "t_string": {
+          "id": "t_string",
+          "kind": "elementary",
+          "label": "string"
+        },
+        "t_array:dyn<t_address>": {
+          "id": "t_array:dyn<t_address>",
+          "valueType": "t_address",
+          "length": "dyn",
+          "kind": "array",
+          "label": "address[]"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 2376,
+          "type": "t_bool",
+          "src": "757:24:14"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 2378,
+          "type": "t_bool",
+          "src": "876:25:14"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 2434,
+          "type": "t_array:50<t_uint256>",
+          "src": "1951:29:14"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_owner",
+          "astId": 971,
+          "type": "t_address",
+          "src": "608:14:5"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_segment",
+          "astId": 973,
+          "type": "t_string",
+          "src": "671:15:5"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_organizations",
+          "astId": 976,
+          "type": "t_array:dyn<t_address>",
+          "src": "747:24:5"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_organizationsIndex",
+          "astId": 980,
+          "type": "t_mapping<t_uint256>",
+          "src": "853:44:5"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_lifToken",
+          "astId": 982,
+          "type": "t_address",
+          "src": "944:17:5"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": []
+      }
+    },
+    "PlaygroundOtaDirectory": {
+      "address": "0x76FEc6493b3786D6B1dE1438976976f0af293cE3",
+      "constructorCode": "608060405234801561001057600080fd5b5061136d806100206000396000f3fe",
+      "bodyBytecodeHash": "0dbcf1bd632b41c9326ab7117400ae431c36bf42b94603d6c4ed1a997794715f",
+      "localBytecodeHash": "8af6b4041cc786152cf36650d9288f68df4181a980f221f66d5e0fa575c21b7e",
+      "deployedBytecodeHash": "8af6b4041cc786152cf36650d9288f68df4181a980f221f66d5e0fa575c21b7e",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_address": {
+          "id": "t_address",
+          "kind": "elementary",
+          "label": "address"
+        },
+        "t_string": {
+          "id": "t_string",
+          "kind": "elementary",
+          "label": "string"
+        },
+        "t_array:dyn<t_address>": {
+          "id": "t_array:dyn<t_address>",
+          "valueType": "t_address",
+          "length": "dyn",
+          "kind": "array",
+          "label": "address[]"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 2376,
+          "type": "t_bool",
+          "src": "757:24:14"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 2378,
+          "type": "t_bool",
+          "src": "876:25:14"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 2434,
+          "type": "t_array:50<t_uint256>",
+          "src": "1951:29:14"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_owner",
+          "astId": 971,
+          "type": "t_address",
+          "src": "608:14:5"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_segment",
+          "astId": 973,
+          "type": "t_string",
+          "src": "671:15:5"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_organizations",
+          "astId": 976,
+          "type": "t_array:dyn<t_address>",
+          "src": "747:24:5"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_organizationsIndex",
+          "astId": 980,
+          "type": "t_mapping<t_uint256>",
+          "src": "853:44:5"
+        },
+        {
+          "contract": "SegmentDirectory",
+          "path": "contracts/SegmentDirectory.sol",
+          "label": "_lifToken",
+          "astId": 982,
+          "type": "t_address",
+          "src": "944:17:5"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": []
       }
     },
     "Organization": {
-      "address": "0x83f64339E20469ddC593cF9253A4983766170e14",
-      "constructorCode": "608060405261001a6301ffc9a760e01b61001f60201b60201c565b6100ed565b7fffffffff0000000000000000000000000000000000000000000000000000000080821614156100b057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601c60248201527f4552433136353a20696e76616c696420696e7465726661636520696400000000604482015290519081900360640190fd5b7fffffffff00000000000000000000000000000000000000000000000000000000166000908152602081905260409020805460ff19166001179055565b610f5b806100fc6000396000f3fe",
-      "bodyBytecodeHash": "500ccabe111a53b3f880e7db0929746eeddbe9bcad8f794c43f4e8190de2e185",
-      "localBytecodeHash": "042f58e02a30606f570148903d38b9d3e3cb2b9e5b1358a165f223e1723e7a5d",
-      "deployedBytecodeHash": "042f58e02a30606f570148903d38b9d3e3cb2b9e5b1358a165f223e1723e7a5d",
+      "address": "0x6a5333Cd9938Bb81aaAa6b9699b2DF8150CaF532",
+      "constructorCode": "608060405261001a6301ffc9a760e01b61001f60201b60201c565b6100ed565b7fffffffff0000000000000000000000000000000000000000000000000000000080821614156100b057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601c60248201527f4552433136353a20696e76616c696420696e7465726661636520696400000000604482015290519081900360640190fd5b7fffffffff00000000000000000000000000000000000000000000000000000000166000908152602081905260409020805460ff19166001179055565b61157a806100fc6000396000f3fe",
+      "bodyBytecodeHash": "8b47729bb63b36555a427ccc180fb52d2ad65e023f351feddab95cf8417692e7",
+      "localBytecodeHash": "b15649733fff34e1b5b06c56afcf442fbb701a3aef7a1fd7f6297d798f0cac58",
+      "deployedBytecodeHash": "b15649733fff34e1b5b06c56afcf442fbb701a3aef7a1fd7f6297d798f0cac58",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -824,6 +812,11 @@
           "length": "dyn",
           "kind": "array",
           "label": "address[]"
+        },
+        "t_bytes32": {
+          "id": "t_bytes32",
+          "kind": "elementary",
+          "label": "bytes32"
         }
       },
       "storage": [
@@ -831,73 +824,81 @@
           "contract": "ERC165",
           "path": "openzeppelin-solidity/contracts/introspection/ERC165.sol",
           "label": "_supportedInterfaces",
-          "astId": 1733,
+          "astId": 3524,
           "type": "t_mapping<t_bool>",
-          "src": "489:52:12"
+          "src": "489:52:25"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initialized",
-          "astId": 1924,
+          "astId": 2376,
           "type": "t_bool",
-          "src": "757:24:15"
+          "src": "757:24:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initializing",
-          "astId": 1926,
+          "astId": 2378,
           "type": "t_bool",
-          "src": "876:25:15"
+          "src": "876:25:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 1982,
+          "astId": 2434,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:15"
+          "src": "1951:29:14"
         },
         {
           "contract": "Organization",
           "path": "contracts/Organization.sol",
           "label": "_owner",
-          "astId": 142,
+          "astId": 146,
           "type": "t_address",
-          "src": "599:14:2"
+          "src": "614:14:2"
         },
         {
           "contract": "Organization",
           "path": "contracts/Organization.sol",
           "label": "orgJsonUri",
-          "astId": 144,
+          "astId": 148,
           "type": "t_string",
-          "src": "793:24:2"
+          "src": "808:24:2"
         },
         {
           "contract": "Organization",
           "path": "contracts/Organization.sol",
           "label": "created",
-          "astId": 146,
+          "astId": 150,
           "type": "t_uint256",
-          "src": "883:19:2"
+          "src": "898:19:2"
         },
         {
           "contract": "Organization",
           "path": "contracts/Organization.sol",
           "label": "associatedKeysIndex",
-          "astId": 150,
+          "astId": 154,
           "type": "t_mapping<t_uint256>",
-          "src": "1040:51:2"
+          "src": "1055:51:2"
         },
         {
           "contract": "Organization",
           "path": "contracts/Organization.sol",
           "label": "associatedKeys",
-          "astId": 153,
+          "astId": 157,
           "type": "t_array:dyn<t_address>",
-          "src": "1255:31:2"
+          "src": "1270:31:2"
+        },
+        {
+          "contract": "Organization",
+          "path": "contracts/Organization.sol",
+          "label": "orgJsonHash",
+          "astId": 159,
+          "type": "t_bytes32",
+          "src": "1549:26:2"
         }
       ],
       "warnings": {
@@ -905,17 +906,15 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [],
-        "storageDiff": []
+        "uninitializedBaseContracts": []
       }
     },
     "OrganizationFactory": {
-      "address": "0xc2C10d80bebB3185381d40b7C371f5387F81c986",
-      "constructorCode": "608060405234801561001057600080fd5b50610cb3806100206000396000f3fe",
-      "bodyBytecodeHash": "a05f757cb009d8f9e1592fafdf36662bc30117b44aab3f96d4504ffc83b2b086",
-      "localBytecodeHash": "60c2778c5ea44eabc7a4d4d832c5aa64bf7cdf3d58b21382c56abb6f88824854",
-      "deployedBytecodeHash": "60c2778c5ea44eabc7a4d4d832c5aa64bf7cdf3d58b21382c56abb6f88824854",
+      "address": "0xa2C34a55F6189Cddde6b28b24E2e5738b76E1699",
+      "constructorCode": "608060405234801561001057600080fd5b50610df2806100206000396000f3fe",
+      "bodyBytecodeHash": "a19df53acb590188d4b1292430faa78fbcb6ea9b5ad64cd49af2b864ff448e2f",
+      "localBytecodeHash": "a5fab23ccda0ef916fb0569896ec1085a967557bae928c52475b952e9f966364",
+      "deployedBytecodeHash": "a5fab23ccda0ef916fb0569896ec1085a967557bae928c52475b952e9f966364",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -956,59 +955,59 @@
       "storage": [
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initialized",
-          "astId": 1924,
+          "astId": 2376,
           "type": "t_bool",
-          "src": "757:24:15"
+          "src": "757:24:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "initializing",
-          "astId": 1926,
+          "astId": 2378,
           "type": "t_bool",
-          "src": "876:25:15"
+          "src": "876:25:14"
         },
         {
           "contract": "Initializable",
-          "path": "zos-lib/contracts/Initializable.sol",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 1982,
+          "astId": 2434,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:15"
+          "src": "1951:29:14"
         },
         {
           "contract": "OrganizationFactory",
           "path": "contracts/OrganizationFactory.sol",
           "label": "app",
-          "astId": 470,
+          "astId": 623,
           "type": "t_address",
-          "src": "569:16:3"
+          "src": "599:16:3"
         },
         {
           "contract": "OrganizationFactory",
           "path": "contracts/OrganizationFactory.sol",
           "label": "_owner",
-          "astId": 472,
+          "astId": 625,
           "type": "t_address",
-          "src": "629:14:3"
+          "src": "659:14:3"
         },
         {
           "contract": "OrganizationFactory",
           "path": "contracts/OrganizationFactory.sol",
           "label": "_createdOrganizations",
-          "astId": 475,
+          "astId": 628,
           "type": "t_array:dyn<t_address>",
-          "src": "933:31:3"
+          "src": "963:31:3"
         },
         {
           "contract": "OrganizationFactory",
           "path": "contracts/OrganizationFactory.sol",
           "label": "_createdOrganizationsIndex",
-          "astId": 479,
+          "astId": 632,
           "type": "t_mapping<t_uint256>",
-          "src": "1054:51:3"
+          "src": "1084:51:3"
         }
       ],
       "warnings": {
@@ -1016,9 +1015,7 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [],
-        "storageDiff": []
+        "uninitializedBaseContracts": []
       }
     }
   },
@@ -1026,41 +1023,56 @@
   "proxies": {
     "wt-contracts/OrganizationFactory": [
       {
-        "address": "0x0EF40ED88A2FeCC129154B9aE3c62e7a1fB6Be67",
-        "version": "0.8.1",
-        "implementation": "0xc2C10d80bebB3185381d40b7C371f5387F81c986",
-        "admin": "0x0458bd87B70fC61fbF92d9D6De469BF81189Ecb1"
+        "address": "0xe2Aabf65CB28352d95964dd9fD1EA0F24E50eF1b",
+        "version": "0.8.2",
+        "implementation": "0xa2C34a55F6189Cddde6b28b24E2e5738b76E1699",
+        "admin": "0xa378E6a57815cA5DCB279EB4D8D6505838BbC237",
+        "kind": "Upgradeable"
       }
     ],
     "wt-contracts/WindingTreeEntrypoint": [
       {
-        "address": "0xefC87a66bDD18F3953B31fF60F47708B7690022b",
-        "version": "0.8.1",
-        "implementation": "0x4e98d051820bA15c0fdE68cD312b95Ee86225e56",
-        "admin": "0x0458bd87B70fC61fbF92d9D6De469BF81189Ecb1"
+        "address": "0xDDFD213784A60B1e0215D2d07d71999cD2A40D34",
+        "version": "0.8.2",
+        "implementation": "0xB5c9Dd467f57937c2b9B8B075757f7D53809B8aE",
+        "admin": "0xa378E6a57815cA5DCB279EB4D8D6505838BbC237",
+        "kind": "Upgradeable"
       }
     ],
-    "wt-contracts/SegmentDirectory": [
+    "wt-contracts/PlaygroundEntrypoint": [
       {
-        "segmentName": "hotels",
-        "address": "0x2D315E8C8E897410A82fDFd615d4C0808e99ff94",
-        "version": "0.8.1",
-        "implementation": "0xB1A1f9Ca5198d60fd8a37C065568984e40250Fad",
-        "admin": "0x0458bd87B70fC61fbF92d9D6De469BF81189Ecb1"
-      },
+        "address": "0xC974dC6eFE2EFAD463DaA97f1f4a88e1c9d62E38",
+        "version": "0.8.2",
+        "implementation": "0x49D248D38AB4572D14E35296664e0345aA66B7f9",
+        "admin": "0xa378E6a57815cA5DCB279EB4D8D6505838BbC237",
+        "kind": "Upgradeable"
+      }
+    ],
+    "wt-contracts/PlaygroundHotelDirectory": [
       {
-        "segmentName": "airlines",
-        "address": "0x512299e6b71D6B9C9F1686b962A3EA4096b4413C",
-        "version": "0.8.1",
-        "implementation": "0xB1A1f9Ca5198d60fd8a37C065568984e40250Fad",
-        "admin": "0x0458bd87B70fC61fbF92d9D6De469BF81189Ecb1"
-      },
+        "address": "0xA63e87b9988c65fA026c4749a448fe9796DD8b7e",
+        "version": "0.8.2",
+        "implementation": "0x9B0fD1380D847bc71efCe7652F53fA730b07443D",
+        "admin": "0xa378E6a57815cA5DCB279EB4D8D6505838BbC237",
+        "kind": "Upgradeable"
+      }
+    ],
+    "wt-contracts/PlaygroundAirlineDirectory": [
       {
-        "segmentName": "otas",
-        "address": "0xD56148CF74971863af984E27213B534dC790783F",
-        "version": "0.8.1",
-        "implementation": "0xB1A1f9Ca5198d60fd8a37C065568984e40250Fad",
-        "admin": "0x0458bd87B70fC61fbF92d9D6De469BF81189Ecb1"
+        "address": "0xBFAcC43B3dF47e1FF8450373A35617956a59f9d9",
+        "version": "0.8.2",
+        "implementation": "0x43D5DCd3E3F6D80FfA723eed64b0BEB22f6B0Fc9",
+        "admin": "0xa378E6a57815cA5DCB279EB4D8D6505838BbC237",
+        "kind": "Upgradeable"
+      }
+    ],
+    "wt-contracts/PlaygroundOtaDirectory": [
+      {
+        "address": "0x90c0b34c08909bf157679c61CDe2fBf00dE69DFb",
+        "version": "0.8.2",
+        "implementation": "0x76FEc6493b3786D6B1dE1438976976f0af293cE3",
+        "admin": "0xa378E6a57815cA5DCB279EB4D8D6505838BbC237",
+        "kind": "Upgradeable"
       }
     ]
   },
@@ -1073,9 +1085,9 @@
     "address": "0x24F95f6677e1279711a3232aCc28277AA879def9"
   },
   "provider": {
-    "address": "0xE8b5e7791e9aaD0ef1C227e55e1c96495aDD3110"
+    "address": "0xBbD4034A92820356f3d3fC9760e1036aF534d3F4"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "proxyAdmin": {
     "address": "0xa378E6a57815cA5DCB279EB4D8D6505838BbC237"
   }


### PR DESCRIPTION
- Redeploy of proxies with new owner and admin accounts, we will be using simple eth accounts for now, we agreed on move to the multisignature on the next upgrade of the proxies and test the upgrade process there.
- Now ropsten and mainnet have the same implementations.
- Fixed dev net commands in readme.